### PR TITLE
Fix tests for new list-based node outputs

### DIFF
--- a/tests/nodetool/test_boolean.py
+++ b/tests/nodetool/test_boolean.py
@@ -70,6 +70,7 @@ def context():
 async def test_boolean_nodes(context: ProcessingContext, node, expected_result):
     try:
         result = await node.process(context)
-        assert result == expected_result
+        assert isinstance(result, list)
+        assert result[0] == expected_result
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")

--- a/tests/nodetool/test_boolean_operations.py
+++ b/tests/nodetool/test_boolean_operations.py
@@ -44,22 +44,26 @@ membership = BooleanOutput(
 @pytest.mark.asyncio
 async def test_basic_comparison():
     result = await graph_result(basic_comparison)
-    assert result is True  # 5 > 3
+    assert isinstance(result, list)
+    assert result[0] is True  # 5 > 3
 
 
 @pytest.mark.asyncio
 async def test_logical_ops():
     result = await graph_result(logical_ops)
-    assert result is True  # (10 > 5) and (20 > 15)
+    assert isinstance(result, list)
+    assert result[0] is True  # (10 > 5) and (20 > 15)
 
 
 @pytest.mark.asyncio
 async def test_conditional():
     result = await graph_result(conditional)
-    assert result == "Values are equal"
+    assert isinstance(result, list)
+    assert result[0] == "Values are equal"
 
 
 @pytest.mark.asyncio
 async def test_membership():
     result = await graph_result(membership)
-    assert result is True  # 5 in [1, 3, 5, 7, 9]
+    assert isinstance(result, list)
+    assert result[0] is True  # 5 in [1, 3, 5, 7, 9]

--- a/tests/nodetool/test_constant.py
+++ b/tests/nodetool/test_constant.py
@@ -60,6 +60,8 @@ async def test_constant_node(context: ProcessingContext, node_class):
 
     try:
         result = await node.process(context)
+        assert isinstance(result, list)
+        result = result[0]
         assert result is not None, f"{node_class.__name__} returned None"
 
         # Additional type checks based on the expected return type

--- a/tests/nodetool/test_dictionary.py
+++ b/tests/nodetool/test_dictionary.py
@@ -25,49 +25,56 @@ def context():
 async def test_get_value(context: ProcessingContext):
     node = GetValue(dictionary=sample_dict, key="a")
     result = await node.process(context)
-    assert result == 1
+    assert isinstance(result, list)
+    assert result[0] == 1
 
 
 @pytest.mark.asyncio
 async def test_update(context: ProcessingContext):
     node = Update(dictionary=sample_dict.copy(), new_pairs={"d": 4})
     result = await node.process(context)
-    assert result == {"a": 1, "b": 2, "c": 3, "d": 4}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 1, "b": 2, "c": 3, "d": 4}
 
 
 @pytest.mark.asyncio
 async def test_remove(context: ProcessingContext):
     node = Remove(dictionary=sample_dict.copy(), key="a")
     result = await node.process(context)
-    assert result == {"b": 2, "c": 3}
+    assert isinstance(result, list)
+    assert result[0] == {"b": 2, "c": 3}
 
 
 @pytest.mark.asyncio
 async def test_parse_json(context: ProcessingContext):
     node = ParseJSON(json_string=sample_json)
     result = await node.process(context)
-    assert result == sample_dict
+    assert isinstance(result, list)
+    assert result[0] == sample_dict
 
 
 @pytest.mark.asyncio
 async def test_zip(context: ProcessingContext):
     node = Zip(keys=["a", "b", "c"], values=[1, 2, 3])
     result = await node.process(context)
-    assert result == sample_dict
+    assert isinstance(result, list)
+    assert result[0] == sample_dict
 
 
 @pytest.mark.asyncio
 async def test_combine(context: ProcessingContext):
     node = Combine(dict_a={"a": 1}, dict_b={"b": 2})
     result = await node.process(context)
-    assert result == {"a": 1, "b": 2}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 1, "b": 2}
 
 
 @pytest.mark.asyncio
 async def test_filter(context: ProcessingContext):
     node = Filter(dictionary=sample_dict, keys=["a", "b"])
     result = await node.process(context)
-    assert result == {"a": 1, "b": 2}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 1, "b": 2}
 
 
 @pytest.mark.asyncio
@@ -82,28 +89,32 @@ async def test_reduce_dictionaries(context: ProcessingContext):
         value_field="value",
     )
     result = await node.process(context)
-    assert result == {1: "a", 2: "b", 3: "c"}
+    assert isinstance(result, list)
+    assert result[0] == {1: "a", 2: "b", 3: "c"}
 
 
 @pytest.mark.asyncio
 async def test_empty_dictionary(context: ProcessingContext):
     node = GetValue(dictionary={}, key="a")
     result = await node.process(context)
-    assert result is None
+    assert isinstance(result, list)
+    assert result[0] is None
 
 
 @pytest.mark.asyncio
 async def test_update_existing_key(context: ProcessingContext):
     node = Update(dictionary=sample_dict.copy(), new_pairs={"a": 10})
     result = await node.process(context)
-    assert result == {"a": 10, "b": 2, "c": 3}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 10, "b": 2, "c": 3}
 
 
 @pytest.mark.asyncio
 async def test_remove_nonexistent_key(context: ProcessingContext):
     node = Remove(dictionary=sample_dict.copy(), key="z")
     result = await node.process(context)
-    assert result == sample_dict
+    assert isinstance(result, list)
+    assert result[0] == sample_dict
 
 
 @pytest.mark.asyncio
@@ -123,11 +134,13 @@ async def test_zip_mismatched_lengths(context: ProcessingContext):
 async def test_combine_with_overlap(context: ProcessingContext):
     node = Combine(dict_a={"a": 1}, dict_b={"a": 2, "b": 2})
     result = await node.process(context)
-    assert result == {"a": 2, "b": 2}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 2, "b": 2}
 
 
 @pytest.mark.asyncio
 async def test_filter_nonexistent_keys(context: ProcessingContext):
     node = Filter(dictionary=sample_dict, keys=["x", "y"])
     result = await node.process(context)
-    assert result == {}
+    assert isinstance(result, list)
+    assert result[0] == {}

--- a/tests/nodetool/test_dictionary_operations.py
+++ b/tests/nodetool/test_dictionary_operations.py
@@ -60,28 +60,33 @@ argmax_example = StringOutput(
 @pytest.mark.asyncio
 async def test_make_dict():
     result = await graph_result(make_dict)
-    assert result == "Developer"
+    assert isinstance(result, list)
+    assert result[0] == "Developer"
 
 
 @pytest.mark.asyncio
 async def test_combined_dict():
     result = await graph_result(combined_dict)
-    assert result == 3
+    assert isinstance(result, list)
+    assert result[0] == 3
 
 
 @pytest.mark.asyncio
 async def test_filtered_dict():
     result = await graph_result(filtered_dict)
-    assert result == {"name": "Bob", "city": "London"}
+    assert isinstance(result, list)
+    assert result[0] == {"name": "Bob", "city": "London"}
 
 
 @pytest.mark.asyncio
 async def test_zipped_dict():
     result = await graph_result(zipped_dict)
-    assert result == {"a": 1, "b": 2, "c": 3}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 1, "b": 2, "c": 3}
 
 
 @pytest.mark.asyncio
 async def test_argmax_example():
     result = await graph_result(argmax_example)
-    assert result == "dog"
+    assert isinstance(result, list)
+    assert result[0] == "dog"

--- a/tests/nodetool/test_input.py
+++ b/tests/nodetool/test_input.py
@@ -124,7 +124,8 @@ async def test_input_nodes(
 
     try:
         result = await node.process(context)
-        assert isinstance(result, expected_type)
+        assert isinstance(result, list)
+        assert isinstance(result[0], expected_type)
 
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")

--- a/tests/nodetool/test_list.py
+++ b/tests/nodetool/test_list.py
@@ -43,7 +43,8 @@ def context():
 async def test_list_nodes(context: ProcessingContext, node, expected_type):
     try:
         result = await node.process(context)
-        assert isinstance(result, expected_type)
+        assert isinstance(result, list)
+        assert isinstance(result[0], expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")
 
@@ -55,14 +56,16 @@ async def test_list_nodes(context: ProcessingContext, node, expected_type):
 async def test_length_node(context: ProcessingContext):
     node = Length(values=[1, 2, 3, 4, 5])
     result = await node.process(context)
-    assert result == 5
+    assert isinstance(result, list)
+    assert result[0] == 5
 
 
 @pytest.mark.asyncio
 async def test_generate_sequence_node(context: ProcessingContext):
     node = GenerateSequence(start=0, stop=5, step=2)
     result = await node.process(context)
-    assert result == [0, 2, 4]
+    assert isinstance(result, list)
+    assert result[0] == [0, 2, 4]
 
 
 @pytest.mark.asyncio

--- a/tests/nodetool/test_list_operations.py
+++ b/tests/nodetool/test_list_operations.py
@@ -85,13 +85,15 @@ dict_list_ops = ListOutput(
 @pytest.mark.asyncio
 async def test_basic_list_ops():
     result = await graph_result(basic_list_ops)
-    assert result == "apple, banana, cherry, date"
+    assert isinstance(result, list)
+    assert result[0] == "apple, banana, cherry, date"
 
 
 @pytest.mark.asyncio
 async def test_list_transform():
     result = await graph_result(list_transform)
-    assert all(x > 2.5 for x in result)
+    assert isinstance(result, list)
+    assert all(x > 2.5 for x in result[0])
 
 
 # @pytest.mark.asyncio
@@ -106,10 +108,12 @@ async def test_list_transform():
 @pytest.mark.asyncio
 async def test_list_sets():
     result = await graph_result(list_sets)
-    assert set(result) == {1, 2, 3, 4, 5, 6}
+    assert isinstance(result, list)
+    assert set(result[0]) == {1, 2, 3, 4, 5, 6}
 
 
 @pytest.mark.asyncio
 async def test_complex_list():
     result = await graph_result(complex_list)
-    assert result == [[1, 2], [3, 4], [5]]
+    assert isinstance(result, list)
+    assert result[0] == [[1, 2], [3, 4], [5]]

--- a/tests/nodetool/test_math.py
+++ b/tests/nodetool/test_math.py
@@ -35,7 +35,8 @@ async def test_basic_math_operations(
 ):
     node = NodeClass(a=a, b=b)
     result = await node.process(context)
-    assert result == expected
+    assert isinstance(result, list)
+    assert result[0] == expected
 
 
 @pytest.mark.asyncio
@@ -53,18 +54,21 @@ async def test_trigonometric_functions(
 ):
     node = NodeClass(angle_rad=input_value)
     result = await node.process(context)
-    assert np.isclose(result, expected)
+    assert isinstance(result, list)
+    assert np.isclose(result[0], expected)
 
 
 @pytest.mark.asyncio
 async def test_power_function(context: ProcessingContext):
     node = Power(base=2, exponent=3)
     result = await node.process(context)
-    assert result == 8
+    assert isinstance(result, list)
+    assert result[0] == 8
 
 
 @pytest.mark.asyncio
 async def test_sqrt_function(context: ProcessingContext):
     node = Sqrt(x=9)
     result = await node.process(context)
-    assert result == 3
+    assert isinstance(result, list)
+    assert result[0] == 3

--- a/tests/nodetool/test_math_operations.py
+++ b/tests/nodetool/test_math_operations.py
@@ -37,28 +37,33 @@ combined_operations = FloatOutput(
 @pytest.mark.asyncio
 async def test_basic_arithmetic():
     result = await graph_result(basic_arithmetic)
-    assert result == 20  # (2 + 3) * 4 = 20
+    assert isinstance(result, list)
+    assert result[0] == 20  # (2 + 3) * 4 = 20
 
 
 @pytest.mark.asyncio
 async def test_pythagorean():
     result = await graph_result(pythagorean)
-    assert pytest.approx(result, 0.0001) == 5.0  # √(3² + 4²) = 5
+    assert isinstance(result, list)
+    assert pytest.approx(result[0], 0.0001) == 5.0  # √(3² + 4²) = 5
 
 
 @pytest.mark.asyncio
 async def test_nested_operations():
     result = await graph_result(nested_operations)
-    assert result == 2.5  # (10 + 5) / (2 * 3) = 15 / 6 = 2.5
+    assert isinstance(result, list)
+    assert result[0] == 2.5  # (10 + 5) / (2 * 3) = 15 / 6 = 2.5
 
 
 @pytest.mark.asyncio
 async def test_trig_calculation():
     result = await graph_result(trig_calculation)
-    assert pytest.approx(result, 0.0001) == 0.5  # sin(π/4)² ≈ 0.5
+    assert isinstance(result, list)
+    assert pytest.approx(result[0], 0.0001) == 0.5  # sin(π/4)² ≈ 0.5
 
 
 @pytest.mark.asyncio
 async def test_combined_operations():
     result = await graph_result(combined_operations)
-    assert result > 0
+    assert isinstance(result, list)
+    assert result[0] > 0

--- a/tests/nodetool/test_text.py
+++ b/tests/nodetool/test_text.py
@@ -50,7 +50,8 @@ dummy_text = TextRef(data=b"Hello, world!")
 async def test_text_nodes(context: ProcessingContext, node, expected_type, mocker):
     try:
         result = await node.process(context)
-        assert isinstance(result, expected_type)
+        assert isinstance(result, list)
+        assert isinstance(result[0], expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")
 
@@ -59,18 +60,21 @@ async def test_text_nodes(context: ProcessingContext, node, expected_type, mocke
 async def test_extract_regex(context: ProcessingContext):
     node = ExtractRegex(text="The year is 2023", regex=r"(\d{4})")
     result = await node.process(context)
-    assert result == ["2023"]
+    assert isinstance(result, list)
+    assert result[0] == ["2023"]
 
 
 @pytest.mark.asyncio
 async def test_parse_json(context: ProcessingContext):
     node = ParseJSON(text='{"a": 1, "b": [2, 3]}')
     result = await node.process(context)
-    assert result == {"a": 1, "b": [2, 3]}
+    assert isinstance(result, list)
+    assert result[0] == {"a": 1, "b": [2, 3]}
 
 
 @pytest.mark.asyncio
 async def test_extract_json(context: ProcessingContext):
     node = ExtractJSON(text='{"a": {"b": {"c": 42}}}', json_path="$.a.b.c")
     result = await node.process(context)
-    assert result == 42
+    assert isinstance(result, list)
+    assert result[0] == 42

--- a/tests/nodetool/test_text_operations.py
+++ b/tests/nodetool/test_text_operations.py
@@ -54,28 +54,33 @@ contains_check = BooleanOutput(
 @pytest.mark.asyncio
 async def test_text_concat():
     result = await graph_result(text_concat)
-    assert result == "Hello, World!"
+    assert isinstance(result, list)
+    assert result[0] == "Hello, World!"
 
 
 @pytest.mark.asyncio
 async def test_template_text():
     result = await graph_result(template_text)
-    assert result == "Hello, Alice! Today is Monday."
+    assert isinstance(result, list)
+    assert result[0] == "Hello, Alice! Today is Monday."
 
 
 @pytest.mark.asyncio
 async def test_regex_replace():
     result = await graph_result(regex_replace)
-    assert result == "The color is blue and gray"
+    assert isinstance(result, list)
+    assert result[0] == "The color is blue and gray"
 
 
 @pytest.mark.asyncio
 async def test_split_join():
     result = await graph_result(split_join)
-    assert result == "apple | banana | orange"
+    assert isinstance(result, list)
+    assert result[0] == "apple | banana | orange"
 
 
 @pytest.mark.asyncio
 async def test_contains_check():
     result = await graph_result(contains_check)
-    assert result is True
+    assert isinstance(result, list)
+    assert result[0] is True

--- a/tests/nodetool/test_video.py
+++ b/tests/nodetool/test_video.py
@@ -95,6 +95,7 @@ def context():
 async def test_video_nodes(context: ProcessingContext, node, expected_type):
     try:
         result = await node.process(context)
-        assert isinstance(result, expected_type)
+        assert isinstance(result, list)
+        assert isinstance(result[0], expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")


### PR DESCRIPTION
## Summary
- update various tests to expect list outputs

## Testing
- `pytest tests/nodetool/test_input.py::test_input_nodes -q` *(fails: Error processing ChatInput)*
- `pytest tests/nodetool/test_math.py::test_basic_math_operations -q` *(fails: assert False)*