### PR TITLE
Fix node test assertions

### DIFF
--- a/tests/nodetool/test_input.py
+++ b/tests/nodetool/test_input.py
@@ -8,6 +8,8 @@ from nodetool.metadata.types import (
     VideoRef,
     FolderRef,
     AssetRef,
+    Message,
+    MessageTextContent,
 )
 from nodetool.nodes.nodetool.input import (
     FloatInput,
@@ -67,9 +69,19 @@ def context():
         (
             ChatInput(
                 name="chat_input",
-                value=[],
+                value=[
+                    Message(
+                        role="user",
+                        content=[MessageTextContent(text="hello")],
+                    )
+                ],
             ),
-            [],
+            [
+                Message(
+                    role="user",
+                    content=[MessageTextContent(text="hello")],
+                )
+            ],
             dict,
         ),
         (
@@ -115,7 +127,7 @@ async def test_input_nodes(
 
     try:
         result = await node.process(context)
-        assert result == expected_type
+        assert isinstance(result, expected_type)
 
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")

--- a/tests/nodetool/test_list.py
+++ b/tests/nodetool/test_list.py
@@ -43,7 +43,7 @@ def context():
 async def test_list_nodes(context: ProcessingContext, node, expected_type):
     try:
         result = await node.process(context)
-        assert result == expected_type
+        assert isinstance(result, expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")
 

--- a/tests/nodetool/test_math.py
+++ b/tests/nodetool/test_math.py
@@ -35,8 +35,7 @@ async def test_basic_math_operations(
 ):
     node = NodeClass(a=a, b=b)
     result = await node.process(context)
-    assert isinstance(result, list)
-    assert result[0] == expected
+    assert result == expected
 
 
 @pytest.mark.asyncio

--- a/tests/nodetool/test_text.py
+++ b/tests/nodetool/test_text.py
@@ -50,8 +50,7 @@ dummy_text = TextRef(data=b"Hello, world!")
 async def test_text_nodes(context: ProcessingContext, node, expected_type, mocker):
     try:
         result = await node.process(context)
-        assert isinstance(result, list)
-        assert isinstance(result[0], expected_type)
+        assert isinstance(result, expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")
 

--- a/tests/nodetool/test_video.py
+++ b/tests/nodetool/test_video.py
@@ -97,6 +97,6 @@ def context():
 async def test_video_nodes(context: ProcessingContext, node, expected_type):
     try:
         result = await node.process(context)
-        assert result == expected_type
+        assert isinstance(result, expected_type)
     except Exception as e:
         pytest.fail(f"Error processing {node.__class__.__name__}: {str(e)}")


### PR DESCRIPTION
## Summary
- update ChatInput test value and check `isinstance` instead of direct equality
- expect scalars in basic math node tests
- use `isinstance` for list, text, and video node tests

## Testing
- `pytest -q`