### PR TITLE
Fix test for ChatInput processing

### DIFF
--- a/tests/nodetool/test_input.py
+++ b/tests/nodetool/test_input.py
@@ -127,8 +127,11 @@ async def test_input_nodes(
         node._value = input_value
 
     if isinstance(node, ChatInput):
-        with pytest.raises(ValueError):
-            await node.process(context)
+        result = await node.process(context)
+        assert isinstance(result, dict)
+        assert result["history"] == input_value[:-1]
+        assert "text" in result
+        assert "tools" in result
         return
 
     try:


### PR DESCRIPTION
## Summary
- update ChatInput test to check for returned dictionary instead of expecting a ValueError

## Testing
- `pytest -q`