### PR TITLE
Add Calendly API integration module

### DIFF
--- a/src/nodetool/nodes/calendly/events.py
+++ b/src/nodetool/nodes/calendly/events.py
@@ -1,0 +1,109 @@
+import asyncio
+from datetime import datetime
+import requests
+from pydantic import Field
+from typing import Literal
+
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.metadata.types import Datetime, BaseType
+from nodetool.common.environment import Environment
+
+
+CALENDLY_API_BASE = "https://api.calendly.com"
+
+
+class CalendlyEvent(BaseType):
+    """Represents a Calendly scheduled event."""
+
+    type: Literal["calendly_event"] = "calendly_event"
+    uri: str = ""
+    name: str = ""
+    start_time: Datetime = Datetime()
+    end_time: Datetime = Datetime()
+    location: str = ""
+
+
+class ListScheduledEvents(BaseNode):
+    """Fetch scheduled events for a Calendly user."""
+
+    user: str = Field(
+        default="",
+        description="User URI to fetch events for",
+    )
+    count: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description="Number of events to return",
+    )
+    status: str = Field(
+        default="active",
+        description="Event status filter",
+    )
+
+    async def process(self, context: ProcessingContext) -> list[CalendlyEvent]:
+        env = Environment.get_environment()
+        token = env.get("CALENDLY_API_TOKEN") or env.get("CALENDLY_TOKEN")
+        if not token:
+            raise ValueError("CALENDLY_API_TOKEN is not set")
+
+        params = {
+            "user": self.user,
+            "count": self.count,
+            "status": self.status,
+            "sort": "start_time:asc",
+        }
+        headers = {"Authorization": f"Bearer {token}"}
+        res = await asyncio.to_thread(
+            requests.get,
+            f"{CALENDLY_API_BASE}/scheduled_events",
+            params=params,
+            headers=headers,
+            timeout=10,
+        )
+        res.raise_for_status()
+        data = res.json().get("collection", [])
+        events = []
+        for e in data:
+            events.append(
+                CalendlyEvent(
+                    uri=e.get("uri", ""),
+                    name=e.get("name", ""),
+                    start_time=Datetime.from_datetime(
+                        datetime.fromisoformat(e.get("start_time"))
+                    ),
+                    end_time=Datetime.from_datetime(
+                        datetime.fromisoformat(e.get("end_time"))
+                    ),
+                    location=e.get("location", {}).get("location", ""),
+                )
+            )
+        return events
+
+
+class ScheduledEventFields(BaseNode):
+    """Extract fields from a CalendlyEvent."""
+
+    event: CalendlyEvent = Field(
+        default=CalendlyEvent(), description="The Calendly event to extract"
+    )
+
+    @classmethod
+    def return_type(cls):
+        return {
+            "uri": str,
+            "name": str,
+            "start_time": Datetime,
+            "end_time": Datetime,
+            "location": str,
+        }
+
+    async def process(self, context: ProcessingContext):
+        return {
+            "uri": self.event.uri,
+            "name": self.event.name,
+            "start_time": self.event.start_time,
+            "end_time": self.event.end_time,
+            "location": self.event.location,
+        }

--- a/src/nodetool/package_metadata/nodetool-base.json
+++ b/src/nodetool/package_metadata/nodetool-base.json
@@ -18397,6 +18397,119 @@
         "quality"
       ],
       "is_dynamic": false
+    },
+    {
+      "title": "List Scheduled Events",
+      "description": "Fetch scheduled events for a Calendly user.\n    calendly, calendar, events",
+      "namespace": "calendly.events",
+      "node_type": "calendly.events.ListScheduledEvents",
+      "layout": "default",
+      "properties": [
+        {
+          "name": "user",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "User",
+          "description": "User URI to fetch events for"
+        },
+        {
+          "name": "count",
+          "type": {
+            "type": "int"
+          },
+          "default": 20,
+          "title": "Count",
+          "description": "Number of events to return"
+        },
+        {
+          "name": "status",
+          "type": {
+            "type": "str"
+          },
+          "default": "active",
+          "title": "Status",
+          "description": "Event status filter"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "list",
+            "type_args": [
+              {
+                "type": "calendly_event"
+              }
+            ]
+          },
+          "name": "output"
+        }
+      ],
+      "the_model_info": {},
+      "recommended_models": [],
+      "basic_fields": [
+        "user",
+        "count",
+        "status"
+      ],
+      "is_dynamic": false
+    },
+    {
+      "title": "Scheduled Event Fields",
+      "description": "Extract fields from a CalendlyEvent.\n    calendly, event, fields",
+      "namespace": "calendly.events",
+      "node_type": "calendly.events.ScheduledEventFields",
+      "layout": "default",
+      "properties": [
+        {
+          "name": "event",
+          "type": {
+            "type": "calendly_event"
+          },
+          "default": {},
+          "title": "Event",
+          "description": "The Calendly event to extract"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "str"
+          },
+          "name": "uri"
+        },
+        {
+          "type": {
+            "type": "str"
+          },
+          "name": "name"
+        },
+        {
+          "type": {
+            "type": "datetime"
+          },
+          "name": "start_time"
+        },
+        {
+          "type": {
+            "type": "datetime"
+          },
+          "name": "end_time"
+        },
+        {
+          "type": {
+            "type": "str"
+          },
+          "name": "location"
+        }
+      ],
+      "the_model_info": {},
+      "recommended_models": [],
+      "basic_fields": [
+        "event"
+      ],
+      "is_dynamic": false
     }
   ],
   "assets": [


### PR DESCRIPTION
## Summary
- integrate Calendly API with new `calendly` node module
- register Calendly nodes in package metadata

## Testing
- `pytest -q` *(fails: DID NOT RAISE <class 'ValueError'>)*