### PR TITLE
Fix pytest asyncio deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add pytest configuration to specify asyncio fixture loop scope

## Testing
- `pytest -q`