### PR TITLE
Add difflib nodes

### DIFF
--- a/src/nodetool/dsl/lib/difflib.py
+++ b/src/nodetool/dsl/lib/difflib.py
@@ -1,0 +1,65 @@
+from pydantic import Field
+from nodetool.dsl.graph import GraphNode
+
+
+class GetCloseMatches(GraphNode):
+    """
+    Finds close matches for a word within a list of possibilities.
+    difflib, fuzzy, match
+
+    Use cases:
+    - Suggest alternatives for misspelled words
+    - Map user input to valid options
+    - Provide recommendations based on partial text
+    """
+
+    word: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Word to match')
+    possibilities: list[str] | GraphNode | tuple[GraphNode, str] = Field(default=[], description='List of possible words')
+    n: int | GraphNode | tuple[GraphNode, str] = Field(default=3, description='Maximum number of matches to return')
+    cutoff: float | GraphNode | tuple[GraphNode, str] = Field(default=0.6, description='Minimum similarity ratio')
+
+    @classmethod
+    def get_node_type(cls): return "lib.difflib.GetCloseMatches"
+
+
+
+class SimilarityRatio(GraphNode):
+    """
+    Calculates the similarity ratio between two strings.
+    difflib, similarity, ratio, compare
+
+    Use cases:
+    - Fuzzy string matching
+    - Compare document versions
+    - Evaluate similarity of user input
+    """
+
+    a: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='First string to compare')
+    b: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Second string to compare')
+
+    @classmethod
+    def get_node_type(cls): return "lib.difflib.SimilarityRatio"
+
+
+
+class UnifiedDiff(GraphNode):
+    """
+    Generates a unified diff between two texts.
+    difflib, diff, compare
+
+    Use cases:
+    - Display differences between versions of text files
+    - Highlight changes in user submitted documents
+    - Compare code snippets
+    """
+
+    a: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Original text')
+    b: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Modified text')
+    fromfile: str | GraphNode | tuple[GraphNode, str] = Field(default='a', description='Name of the original file')
+    tofile: str | GraphNode | tuple[GraphNode, str] = Field(default='b', description='Name of the modified file')
+    lineterm: str | GraphNode | tuple[GraphNode, str] = Field(default='\n', description='Line terminator')
+
+    @classmethod
+    def get_node_type(cls): return "lib.difflib.UnifiedDiff"
+
+

--- a/src/nodetool/nodes/lib/difflib.py
+++ b/src/nodetool/nodes/lib/difflib.py
@@ -1,0 +1,86 @@
+from difflib import SequenceMatcher, get_close_matches, unified_diff
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class SimilarityRatio(BaseNode):
+    """
+    Calculates the similarity ratio between two strings.
+    difflib, similarity, ratio, compare
+
+    Use cases:
+    - Fuzzy string matching
+    - Compare document versions
+    - Evaluate similarity of user input
+    """
+
+    a: str = Field(default="", description="First string to compare")
+    b: str = Field(default="", description="Second string to compare")
+
+    @classmethod
+    def get_title(cls):
+        return "Sequence Similarity Ratio"
+
+    async def process(self, context: ProcessingContext) -> float:
+        return SequenceMatcher(None, self.a, self.b).ratio()
+
+
+class GetCloseMatches(BaseNode):
+    """
+    Finds close matches for a word within a list of possibilities.
+    difflib, fuzzy, match
+
+    Use cases:
+    - Suggest alternatives for misspelled words
+    - Map user input to valid options
+    - Provide recommendations based on partial text
+    """
+
+    word: str = Field(default="", description="Word to match")
+    possibilities: list[str] = Field(default=[], description="List of possible words")
+    n: int = Field(default=3, ge=1, description="Maximum number of matches to return")
+    cutoff: float = Field(
+        default=0.6, ge=0.0, le=1.0, description="Minimum similarity ratio"
+    )
+
+    @classmethod
+    def get_title(cls):
+        return "Get Close Matches"
+
+    async def process(self, context: ProcessingContext) -> list[str]:
+        return get_close_matches(
+            self.word, self.possibilities, n=self.n, cutoff=self.cutoff
+        )
+
+
+class UnifiedDiff(BaseNode):
+    """
+    Generates a unified diff between two texts.
+    difflib, diff, compare
+
+    Use cases:
+    - Display differences between versions of text files
+    - Highlight changes in user submitted documents
+    - Compare code snippets
+    """
+
+    a: str = Field(default="", description="Original text")
+    b: str = Field(default="", description="Modified text")
+    fromfile: str = Field(default="a", description="Name of the original file")
+    tofile: str = Field(default="b", description="Name of the modified file")
+    lineterm: str = Field(default="\n", description="Line terminator")
+
+    @classmethod
+    def get_title(cls):
+        return "Unified Diff"
+
+    async def process(self, context: ProcessingContext) -> str:
+        diff_lines = unified_diff(
+            self.a.splitlines(),
+            self.b.splitlines(),
+            fromfile=self.fromfile,
+            tofile=self.tofile,
+            lineterm=self.lineterm,
+        )
+        return "\n".join(diff_lines)

--- a/tests/nodetool/test_difflib.py
+++ b/tests/nodetool/test_difflib.py
@@ -1,0 +1,37 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.lib.difflib import (
+    SimilarityRatio,
+    GetCloseMatches,
+    UnifiedDiff,
+)
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_similarity_ratio(context: ProcessingContext):
+    node = SimilarityRatio(a="hello", b="hallo")
+    result = await node.process(context)
+    assert result > 0.7
+
+
+@pytest.mark.asyncio
+async def test_get_close_matches(context: ProcessingContext):
+    node = GetCloseMatches(
+        word="appel", possibilities=["ape", "apple", "peach"], n=2, cutoff=0.6
+    )
+    result = await node.process(context)
+    assert "apple" in result
+
+
+@pytest.mark.asyncio
+async def test_unified_diff(context: ProcessingContext):
+    node = UnifiedDiff(
+        a="a\nb\n", b="a\nc\n", fromfile="old", tofile="new", lineterm=""
+    )
+    result = await node.process(context)
+    assert "--- old" in result and "+++ new" in result


### PR DESCRIPTION
## Summary
- implement difflib nodes for similarity, matching, and unified diffs
- expose difflib nodes via DSL
- test the new nodes

## Testing
- `black --config /dev/null src/nodetool/nodes/lib/difflib.py tests/nodetool/test_difflib.py`
- `ruff check src/nodetool/dsl/lib/difflib.py`
- `flake8 src/nodetool/dsl/lib/difflib.py src/nodetool/nodes/lib/difflib.py tests/nodetool/test_difflib.py`
- `mypy src/nodetool/nodes/lib/difflib.py tests/nodetool/test_difflib.py` *(fails: Module "difflib" has no attribute)*
- `PYTHONPATH=$PWD/src pytest tests/nodetool/test_difflib.py -q`