### PR TITLE
Add HTML library nodes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ permalink: /
 ## Available Nodes
 
 - **[lib.audio](nodetool_audio.md)** - Save audio files to the assets directory.
+- **[lib.html](nodetool_html.md)** - HTML utility nodes.
 - **[nodetool.boolean](nodetool_boolean.md)** - Logical operators, comparisons and flow control helpers.
 - **[nodetool.code](nodetool_code.md)** - Evaluate expressions or run small Python snippets (development use).
 - **[nodetool.constant](nodetool_constant.md)** - Provide constant values like numbers, strings and images.

--- a/docs/nodetool_html.md
+++ b/docs/nodetool_html.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: lib.html
+parent: Nodes
+has_children: false
+nav_order: 2
+---
+
+# nodetool.nodes.lib.html

--- a/src/nodetool/dsl/lib/html.py
+++ b/src/nodetool/dsl/lib/html.py
@@ -1,0 +1,44 @@
+from pydantic import Field
+from nodetool.dsl.graph import GraphNode
+
+
+class Escape(GraphNode):
+    """
+    Escape special characters in text into HTML-safe sequences.
+    html, escape, entities, convert
+
+    Use cases:
+    - Prepare text for inclusion in HTML
+    - Prevent cross-site scripting in user content
+    - Encode strings for web output
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="",
+        description="The text to escape",
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "lib.html.Escape"
+
+
+class Unescape(GraphNode):
+    """
+    Convert HTML entities back to normal text.
+    html, unescape, entities, decode
+
+    Use cases:
+    - Decode HTML-encoded data
+    - Process text scraped from the web
+    - Convert form submissions to plain text
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="",
+        description="The HTML text to unescape",
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "lib.html.Unescape"

--- a/src/nodetool/nodes/lib/html.py
+++ b/src/nodetool/nodes/lib/html.py
@@ -1,0 +1,38 @@
+import html
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class Escape(BaseNode):
+    """
+    Escape special characters in text into HTML-safe sequences.
+    html, escape, entities, convert
+
+    Use cases:
+    - Prepare text for inclusion in HTML
+    - Prevent cross-site scripting in user content
+    - Encode strings for web output
+    """
+
+    text: str = Field(default="", description="The text to escape")
+
+    async def process(self, context: ProcessingContext) -> str:
+        return html.escape(self.text)
+
+
+class Unescape(BaseNode):
+    """
+    Convert HTML entities back to normal text.
+    html, unescape, entities, decode
+
+    Use cases:
+    - Decode HTML-encoded data
+    - Process text scraped from the web
+    - Convert form submissions to plain text
+    """
+
+    text: str = Field(default="", description="The HTML text to unescape")
+
+    async def process(self, context: ProcessingContext) -> str:
+        return html.unescape(self.text)

--- a/tests/nodetool/test_html.py
+++ b/tests/nodetool/test_html.py
@@ -1,0 +1,29 @@
+import pytest
+from nodetool.dsl.graph import graph_result
+from nodetool.dsl.lib.html import Escape, Unescape
+from nodetool.dsl.nodetool.output import StringOutput
+
+escape_node = StringOutput(
+    name="escape_node", value=Escape(text="Hello <world> & 'AI'")
+)
+
+unescape_node = StringOutput(
+    name="unescape_node",
+    value=Unescape(
+        text="Hello &lt;world&gt; &amp; &#39;AI&#39;",
+    ),
+)
+
+
+@pytest.mark.asyncio
+async def test_escape():
+    result = await graph_result(escape_node)
+    assert isinstance(result, list)
+    assert result[0] == "Hello &lt;world&gt; &amp; &#39;AI&#39;"
+
+
+@pytest.mark.asyncio
+async def test_unescape():
+    result = await graph_result(unescape_node)
+    assert isinstance(result, list)
+    assert result[0] == "Hello <world> & 'AI'"


### PR DESCRIPTION
## Summary
- implement basic `Escape` and `Unescape` nodes for HTML escaping
- expose HTML nodes through DSL classes
- document HTML node category
- add tests for escape/unescape nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*
- `black src/nodetool/dsl/lib/html.py src/nodetool/nodes/lib/html.py tests/nodetool/test_html.py`
- `ruff check src/nodetool/dsl/lib/html.py src/nodetool/nodes/lib/html.py tests/nodetool/test_html.py`
- `mypy .`
- `flake8 src/nodetool/dsl/lib/html.py src/nodetool/nodes/lib/html.py tests/nodetool/test_html.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.dsl.lib.html')*
- `nodetool package scan`
- `nodetool codegen`
