### PR TITLE
Add textwrap nodes

### DIFF
--- a/src/nodetool/dsl/nodetool/textwrap.py
+++ b/src/nodetool/dsl/nodetool/textwrap.py
@@ -1,0 +1,80 @@
+from pydantic import BaseModel, Field
+import typing
+from typing import Any
+import nodetool.metadata.types
+import nodetool.metadata.types as types
+from nodetool.dsl.graph import GraphNode
+
+
+class Dedent(GraphNode):
+    """
+    Removes any common leading whitespace from every line in text.
+    textwrap, dedent, whitespace
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default="", description=None)
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.textwrap.Dedent"
+
+
+class Fill(GraphNode):
+    """
+    Wraps text to a specified width, returning a formatted string.
+    textwrap, fill, wrap
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default="", description=None)
+    width: int | GraphNode | tuple[GraphNode, str] = Field(default=70, description=None)
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.textwrap.Fill"
+
+
+class Indent(GraphNode):
+    """
+    Adds a prefix to the beginning of each line in the text.
+    textwrap, indent, prefix
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default="", description=None)
+    prefix: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="    ", description=None
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.textwrap.Indent"
+
+
+class Shorten(GraphNode):
+    """
+    Shortens text to fit within a width, using a placeholder if truncated.
+    textwrap, shorten, truncate
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default="", description=None)
+    width: int | GraphNode | tuple[GraphNode, str] = Field(default=70, description=None)
+    placeholder: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="...", description=None
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.textwrap.Shorten"
+
+
+class Wrap(GraphNode):
+    """
+    Wraps text to a specified width, returning a list of lines.
+    textwrap, wrap, lines
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default="", description=None)
+    width: int | GraphNode | tuple[GraphNode, str] = Field(default=70, description=None)
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.textwrap.Wrap"

--- a/src/nodetool/nodes/nodetool/textwrap.py
+++ b/src/nodetool/nodes/nodetool/textwrap.py
@@ -1,0 +1,91 @@
+import textwrap
+from pydantic import Field
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.workflows.base_node import BaseNode
+
+
+class Fill(BaseNode):
+    """
+    Wraps text to a specified width, returning a formatted string.
+    textwrap, fill, wrap
+    """
+
+    text: str = Field(title="Text", default="")
+    width: int = Field(title="Width", default=70, ge=1)
+
+    @classmethod
+    def get_title(cls):
+        return "Fill Text"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return textwrap.fill(self.text, width=self.width)
+
+
+class Wrap(BaseNode):
+    """
+    Wraps text to a specified width, returning a list of lines.
+    textwrap, wrap, lines
+    """
+
+    text: str = Field(title="Text", default="")
+    width: int = Field(title="Width", default=70, ge=1)
+
+    @classmethod
+    def get_title(cls):
+        return "Wrap Text"
+
+    async def process(self, context: ProcessingContext) -> list[str]:
+        return textwrap.wrap(self.text, width=self.width)
+
+
+class Shorten(BaseNode):
+    """
+    Shortens text to fit within a width, using a placeholder if truncated.
+    textwrap, shorten, truncate
+    """
+
+    text: str = Field(title="Text", default="")
+    width: int = Field(title="Width", default=70, ge=1)
+    placeholder: str = Field(title="Placeholder", default="...")
+
+    @classmethod
+    def get_title(cls):
+        return "Shorten Text"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return textwrap.shorten(
+            self.text, width=self.width, placeholder=self.placeholder
+        )
+
+
+class Indent(BaseNode):
+    """
+    Adds a prefix to the beginning of each line in the text.
+    textwrap, indent, prefix
+    """
+
+    text: str = Field(title="Text", default="")
+    prefix: str = Field(title="Prefix", default="    ")
+
+    @classmethod
+    def get_title(cls):
+        return "Indent Text"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return textwrap.indent(self.text, prefix=self.prefix)
+
+
+class Dedent(BaseNode):
+    """
+    Removes any common leading whitespace from every line in text.
+    textwrap, dedent, whitespace
+    """
+
+    text: str = Field(title="Text", default="")
+
+    @classmethod
+    def get_title(cls):
+        return "Dedent Text"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return textwrap.dedent(self.text)

--- a/tests/nodetool/test_textwrap.py
+++ b/tests/nodetool/test_textwrap.py
@@ -1,0 +1,27 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.nodetool.textwrap import Fill, Wrap, Shorten, Indent, Dedent
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "node, expected",
+    [
+        (Fill(text="hello world", width=5), "hello\nworld"),
+        (Wrap(text="hello world", width=5), ["hello", "world"]),
+        (
+            Shorten(text="hello wonderful world", width=10, placeholder="..."),
+            "hello ...",
+        ),
+        (Indent(text="a\nb", prefix="*>"), "*>a\n*>b"),
+        (Dedent(text="    a\n    b"), "a\nb"),
+    ],
+)
+async def test_textwrap_nodes(context: ProcessingContext, node, expected):
+    result = await node.process(context)
+    assert result == expected


### PR DESCRIPTION
## Summary
- add nodes wrapping Python `textwrap` functions
- generate DSL wrappers for the new nodes
- test the new textwrap nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*
- `black .`
- `ruff check .`
- `mypy .`
- `flake8`
- `nodetool package scan`
- `nodetool codegen`
- `pytest -q` *(fails: ModuleNotFoundError for nodetool.nodes.nodetool.textwrap)*
