### PR TITLE
Add random utility nodes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ permalink: /
 - **[nodetool.json](nodetool_json.md)** - Parse, query and validate JSON data.
 - **[nodetool.list](nodetool_list.md)** - List processing utilities.
 - **[nodetool.math](nodetool_math.md)** - Basic arithmetic and math functions.
+- **[nodetool.random](nodetool_random.md)** - Generate random numbers and selections.
 - **[nodetool.os](nodetool_os.md)** - File system and path helpers.
 - **[nodetool.output](nodetool_output.md)** - Output nodes to return results to the user.
 - **[nodetool.text](nodetool_text.md)** - Text processing nodes with regex and templating.

--- a/docs/nodetool_random.md
+++ b/docs/nodetool_random.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: nodetool.random
+parent: Nodes
+has_children: false
+nav_order: 2
+---
+
+# nodetool.nodes.nodetool.random
+
+Random utilities for generating random data.
+
+## RandomBool
+
+Return a random boolean value.
+
+Use cases:
+- Make random yes/no decisions
+- Simulate coin flips
+- Introduce randomness in control flow
+
+**Tags:** random, boolean, coinflip, bool
+
+**Fields:**
+
+
+## RandomChoice
+
+Select a random element from a list.
+
+Use cases:
+- Choose a random sample from options
+- Implement simple lottery behaviour
+- Pick a random item from user input
+
+**Tags:** random, choice, select, pick
+
+**Fields:**
+- **options** (list[typing.Any])
+
+
+## RandomFloat
+
+Generate a random floating point number within a range.
+
+Use cases:
+- Create random probabilities
+- Generate noisy data for testing
+- Produce random values for simulations
+
+**Tags:** random, float, number, rand, uniform
+
+**Fields:**
+- **minimum** (float)
+- **maximum** (float)
+
+
+## RandomInt
+
+Generate a random integer within a range.
+
+Use cases:
+- Pick a random index or identifier
+- Create randomized counters or IDs
+- Sample integers for testing
+
+**Tags:** random, integer, number, rand, randint
+
+**Fields:**
+- **minimum** (int)
+- **maximum** (int)

--- a/src/nodetool/dsl/nodetool/random.py
+++ b/src/nodetool/dsl/nodetool/random.py
@@ -1,0 +1,85 @@
+from typing import Any
+from pydantic import Field
+from nodetool.dsl.graph import GraphNode
+
+
+class RandomBool(GraphNode):
+    """
+    Return a random boolean value.
+    random, boolean, coinflip, bool
+
+    Use cases:
+    - Make random yes/no decisions
+    - Simulate coin flips
+    - Introduce randomness in control flow
+    """
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.random.RandomBool"
+
+
+class RandomChoice(GraphNode):
+    """
+    Select a random element from a list.
+    random, choice, select, pick
+
+    Use cases:
+    - Choose a random sample from options
+    - Implement simple lottery behaviour
+    - Pick a random item from user input
+    """
+
+    options: list[Any] | GraphNode | tuple[GraphNode, str] = Field(
+        default=[], description="List of options"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.random.RandomChoice"
+
+
+class RandomFloat(GraphNode):
+    """
+    Generate a random floating point number within a range.
+    random, float, number, rand, uniform
+
+    Use cases:
+    - Create random probabilities
+    - Generate noisy data for testing
+    - Produce random values for simulations
+    """
+
+    minimum: float | GraphNode | tuple[GraphNode, str] = Field(
+        default=0.0, description="Minimum value"
+    )
+    maximum: float | GraphNode | tuple[GraphNode, str] = Field(
+        default=1.0, description="Maximum value"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.random.RandomFloat"
+
+
+class RandomInt(GraphNode):
+    """
+    Generate a random integer within a range.
+    random, integer, number, rand, randint
+
+    Use cases:
+    - Pick a random index or identifier
+    - Create randomized counters or IDs
+    - Sample integers for testing
+    """
+
+    minimum: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=0, description="Minimum value (inclusive)"
+    )
+    maximum: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=100, description="Maximum value (inclusive)"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.random.RandomInt"

--- a/src/nodetool/nodes/nodetool/random.py
+++ b/src/nodetool/nodes/nodetool/random.py
@@ -1,0 +1,75 @@
+import random
+from typing import Any
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class RandomInt(BaseNode):
+    """
+    Generate a random integer within a range.
+    random, integer, number, rand, randint
+
+    Use cases:
+    - Pick a random index or identifier
+    - Create randomized counters or IDs
+    - Sample integers for testing
+    """
+
+    minimum: int = Field(default=0, description="Minimum value (inclusive)")
+    maximum: int = Field(default=100, description="Maximum value (inclusive)")
+
+    async def process(self, context: ProcessingContext) -> int:
+        return random.randint(self.minimum, self.maximum)
+
+
+class RandomFloat(BaseNode):
+    """
+    Generate a random floating point number within a range.
+    random, float, number, rand, uniform
+
+    Use cases:
+    - Create random probabilities
+    - Generate noisy data for testing
+    - Produce random values for simulations
+    """
+
+    minimum: float = Field(default=0.0, description="Minimum value")
+    maximum: float = Field(default=1.0, description="Maximum value")
+
+    async def process(self, context: ProcessingContext) -> float:
+        return random.uniform(self.minimum, self.maximum)
+
+
+class RandomChoice(BaseNode):
+    """
+    Select a random element from a list.
+    random, choice, select, pick
+
+    Use cases:
+    - Choose a random sample from options
+    - Implement simple lottery behaviour
+    - Pick a random item from user input
+    """
+
+    options: list[Any] = Field(default=[], description="List of options")
+
+    async def process(self, context: ProcessingContext) -> Any:
+        if not self.options:
+            raise ValueError("options list is empty")
+        return random.choice(self.options)
+
+
+class RandomBool(BaseNode):
+    """
+    Return a random boolean value.
+    random, boolean, coinflip, bool
+
+    Use cases:
+    - Make random yes/no decisions
+    - Simulate coin flips
+    - Introduce randomness in control flow
+    """
+
+    async def process(self, context: ProcessingContext) -> bool:
+        return random.choice([True, False])

--- a/tests/nodetool/test_random.py
+++ b/tests/nodetool/test_random.py
@@ -1,0 +1,42 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.nodetool.random import (
+    RandomInt,
+    RandomFloat,
+    RandomChoice,
+    RandomBool,
+)
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_random_int_range(context: ProcessingContext):
+    node = RandomInt(minimum=1, maximum=3)
+    result = await node.process(context)
+    assert 1 <= result <= 3
+
+
+@pytest.mark.asyncio
+async def test_random_float_range(context: ProcessingContext):
+    node = RandomFloat(minimum=0.5, maximum=1.5)
+    result = await node.process(context)
+    assert 0.5 <= result <= 1.5
+
+
+@pytest.mark.asyncio
+async def test_random_choice(context: ProcessingContext):
+    options = ["a", "b", "c"]
+    node = RandomChoice(options=options)
+    result = await node.process(context)
+    assert result in options
+
+
+@pytest.mark.asyncio
+async def test_random_bool(context: ProcessingContext):
+    node = RandomBool()
+    result = await node.process(context)
+    assert isinstance(result, bool)


### PR DESCRIPTION
## Summary
- add random module with nodes for integers, floats, booleans and list choice
- create DSL wrappers for the random nodes
- document new nodes
- list random docs in the index
- test the random nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.nodes.nodetool.random')*
- `PYTHONPATH=src pytest tests/nodetool/test_random.py -q`
- `black src/nodetool/nodes/nodetool/random.py tests/nodetool/test_random.py src/nodetool/dsl/nodetool/random.py`
- `ruff check src/nodetool/dsl/nodetool/random.py`
- `mypy .`
- `flake8 src/nodetool/nodes/nodetool/random.py tests/nodetool/test_random.py src/nodetool/dsl/nodetool/random.py`
- `nodetool package scan`
- `nodetool codegen`