### PR TITLE
Add zlib compression nodes

### DIFF
--- a/src/nodetool/dsl/lib/zlib.py
+++ b/src/nodetool/dsl/lib/zlib.py
@@ -1,0 +1,49 @@
+from pydantic import BaseModel, Field
+import typing
+from typing import Any
+import nodetool.metadata.types
+import nodetool.metadata.types as types
+from nodetool.dsl.graph import GraphNode
+
+
+class Compress(GraphNode):
+    """
+    Compress binary data using the zlib algorithm.
+    zlib, compress, deflate, binary
+
+    Use cases:
+    - Reduce size of binary data
+    - Prepare payloads for transmission
+    - Store data in compressed form
+    """
+
+    data: bytes | GraphNode | tuple[GraphNode, str] = Field(
+        default=b"", description="Data to compress"
+    )
+    level: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=9, description="Compression level"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "lib.zlib.Compress"
+
+
+class Decompress(GraphNode):
+    """
+    Decompress zlib-compressed binary data.
+    zlib, decompress, inflate, binary
+
+    Use cases:
+    - Restore compressed payloads
+    - Read previously compressed files
+    - Handle zlib streams from external services
+    """
+
+    data: bytes | GraphNode | tuple[GraphNode, str] = Field(
+        default=b"", description="Data to decompress"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "lib.zlib.Decompress"

--- a/src/nodetool/nodes/lib/zlib.py
+++ b/src/nodetool/nodes/lib/zlib.py
@@ -1,0 +1,39 @@
+import zlib
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class Compress(BaseNode):
+    """
+    Compress binary data using the zlib algorithm.
+    zlib, compress, deflate, binary
+
+    Use cases:
+    - Reduce size of binary data
+    - Prepare payloads for transmission
+    - Store data in compressed form
+    """
+
+    data: bytes = Field(default=b"", description="Data to compress")
+    level: int = Field(default=9, ge=0, le=9, description="Compression level")
+
+    async def process(self, context: ProcessingContext) -> bytes:
+        return zlib.compress(self.data, self.level)
+
+
+class Decompress(BaseNode):
+    """
+    Decompress zlib-compressed binary data.
+    zlib, decompress, inflate, binary
+
+    Use cases:
+    - Restore compressed payloads
+    - Read previously compressed files
+    - Handle zlib streams from external services
+    """
+
+    data: bytes = Field(default=b"", description="Data to decompress")
+
+    async def process(self, context: ProcessingContext) -> bytes:
+        return zlib.decompress(self.data)

--- a/tests/nodetool/test_zlib.py
+++ b/tests/nodetool/test_zlib.py
@@ -1,0 +1,17 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.lib import zlib as zlib_nodes
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_compress_decompress_roundtrip(context):
+    original = b"hello world" * 10
+    compressed = await zlib_nodes.Compress(data=original).process(context)
+    assert isinstance(compressed, bytes)
+    decompressed = await zlib_nodes.Decompress(data=compressed).process(context)
+    assert decompressed == original


### PR DESCRIPTION
## Summary
- add zlib compression/decompression nodes
- provide DSL wrappers
- add unit test for roundtrip compression

## Testing
- `pytest tests/nodetool/test_zlib.py -q`
- `ruff check src/nodetool/nodes/lib/zlib.py src/nodetool/dsl/lib/zlib.py tests/nodetool/test_zlib.py` *(fails: F401 unused imports)*
- `mypy src/nodetool/nodes/lib/zlib.py tests/nodetool/test_zlib.py` *(fails: missing stubs & attr-defined errors)*
- `flake8 src/nodetool/nodes/lib/zlib.py tests/nodetool/test_zlib.py`
- `nodetool package scan` *(fails: feedparser missing)*
- `nodetool codegen` *(fails: feedparser missing)*