### PR TITLE
Add hashlib nodes

### DIFF
--- a/src/nodetool/nodes/lib/hashlib.py
+++ b/src/nodetool/nodes/lib/hashlib.py
@@ -1,0 +1,61 @@
+import hashlib
+from pydantic import Field
+from nodetool.metadata.types import FilePath
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class HashString(BaseNode):
+    """Compute the cryptographic hash of a string using hashlib.
+    hash, hashlib, digest, string
+
+    Use cases:
+    - Generate deterministic identifiers
+    - Verify data integrity
+    - Create fingerprints for caching
+    """
+
+    text: str = Field(default="", description="The text to hash")
+    algorithm: str = Field(
+        default="md5",
+        description="Hash algorithm name (e.g. md5, sha1, sha256)",
+    )
+
+    async def process(self, context: ProcessingContext) -> str:
+        try:
+            hasher = getattr(hashlib, self.algorithm)()
+        except AttributeError as exc:
+            raise ValueError(f"Unsupported algorithm: {self.algorithm}") from exc
+        hasher.update(self.text.encode("utf-8"))
+        return hasher.hexdigest()
+
+
+class HashFile(BaseNode):
+    """Compute the cryptographic hash of a file.
+    hash, hashlib, digest, file
+
+    Use cases:
+    - Verify downloaded files
+    - Detect file changes
+    - Identify duplicates
+    """
+
+    file: FilePath = Field(default=FilePath(), description="The file to hash")
+    algorithm: str = Field(
+        default="md5",
+        description="Hash algorithm name (e.g. md5, sha1, sha256)",
+    )
+    chunk_size: int = Field(
+        default=8192, ge=1, description="Read size for hashing in bytes"
+    )
+
+    async def process(self, context: ProcessingContext) -> str:
+        try:
+            hasher = getattr(hashlib, self.algorithm)()
+        except AttributeError as exc:
+            raise ValueError(f"Unsupported algorithm: {self.algorithm}") from exc
+
+        with open(self.file.path, "rb") as f:
+            for chunk in iter(lambda: f.read(self.chunk_size), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()

--- a/tests/nodetool/test_hashlib_nodes.py
+++ b/tests/nodetool/test_hashlib_nodes.py
@@ -1,0 +1,26 @@
+import hashlib
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.metadata.types import FilePath
+from nodetool.nodes.lib.hashlib import HashString, HashFile
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_hash_string_md5(context: ProcessingContext):
+    node = HashString(text="hello", algorithm="md5")
+    result = await node.process(context)
+    assert result == hashlib.md5(b"hello").hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_hash_file_sha256(context: ProcessingContext, tmp_path):
+    file = tmp_path / "data.txt"
+    file.write_text("world")
+    node = HashFile(file=FilePath(path=str(file)), algorithm="sha256")
+    result = await node.process(context)
+    assert result == hashlib.sha256(b"world").hexdigest()


### PR DESCRIPTION
## Summary
- add HashString and HashFile nodes to lib namespace
- test hashlib nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*
- `ruff check .`
- `mypy .`
- `flake8` *(fails: many style violations)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.nodes.nodetool.audio')*
- `nodetool package scan`
- `nodetool codegen`