### PR TITLE
Add Base64 nodes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ permalink: /
 
 - **[lib.audio](nodetool_audio.md)** - Save audio files to the assets directory.
 - **[nodetool.boolean](nodetool_boolean.md)** - Logical operators, comparisons and flow control helpers.
+- **[nodetool.base64](nodetool_base64.md)** - Base64 encoding and decoding utilities.
 - **[nodetool.code](nodetool_code.md)** - Evaluate expressions or run small Python snippets (development use).
 - **[nodetool.constant](nodetool_constant.md)** - Provide constant values like numbers, strings and images.
 - **[nodetool.control](nodetool_control.md)** - Basic branching with an if node.

--- a/docs/nodetool_base64.md
+++ b/docs/nodetool_base64.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: nodetool.base64
+parent: Nodes
+has_children: false
+nav_order: 2
+---
+
+# nodetool.nodes.nodetool.base64
+
+Base64 encoding and decoding utilities.
+
+## Encode
+
+Encodes text to Base64 format.
+
+Use cases:
+- Prepare text for transmission
+- Embed data in JSON or HTML
+
+**Tags:** base64, encode, string
+
+**Fields:**
+- **text** (str)
+
+## Decode
+
+Decodes Base64 text to plain string.
+
+Use cases:
+- Read encoded data
+- Extract original text from Base64
+
+**Tags:** base64, decode, string
+
+**Fields:**
+- **data** (str)

--- a/src/nodetool/dsl/nodetool/base64.py
+++ b/src/nodetool/dsl/nodetool/base64.py
@@ -1,0 +1,38 @@
+from pydantic import Field
+from nodetool.dsl.graph import GraphNode
+
+
+class Decode(GraphNode):
+    """Decodes Base64 text to plain string.
+    base64, decode, string
+
+    Use cases:
+    - Read encoded data
+    - Extract original text from Base64
+    """
+
+    data: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="Base64 encoded text"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.base64.Decode"
+
+
+class Encode(GraphNode):
+    """Encodes text to Base64 format.
+    base64, encode, string
+
+    Use cases:
+    - Prepare text for transmission
+    - Embed data in JSON or HTML
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="Text to encode"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "nodetool.base64.Encode"

--- a/src/nodetool/nodes/nodetool/base64.py
+++ b/src/nodetool/nodes/nodetool/base64.py
@@ -1,0 +1,42 @@
+import base64
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class Encode(BaseNode):
+    """Encodes text to Base64 format.
+    base64, encode, string
+
+    Use cases:
+    - Prepare text for transmission
+    - Embed data in JSON or HTML
+    """
+
+    text: str = Field(default="", description="Text to encode")
+
+    @classmethod
+    def get_title(cls):
+        return "Encode Base64"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return base64.b64encode(self.text.encode()).decode()
+
+
+class Decode(BaseNode):
+    """Decodes Base64 text to plain string.
+    base64, decode, string
+
+    Use cases:
+    - Read encoded data
+    - Extract original text from Base64
+    """
+
+    data: str = Field(default="", description="Base64 encoded text")
+
+    @classmethod
+    def get_title(cls):
+        return "Decode Base64"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return base64.b64decode(self.data.encode()).decode()

--- a/tests/nodetool/test_base64_nodes.py
+++ b/tests/nodetool/test_base64_nodes.py
@@ -1,0 +1,22 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.nodetool.base64 import Encode, Decode
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_encode_base64(context: ProcessingContext):
+    node = Encode(text="hello")
+    result = await node.process(context)
+    assert result == "aGVsbG8="
+
+
+@pytest.mark.asyncio
+async def test_decode_base64(context: ProcessingContext):
+    node = Decode(data="aGVsbG8=")
+    result = await node.process(context)
+    assert result == "hello"


### PR DESCRIPTION
## Summary
- add new `Encode` and `Decode` Base64 nodes
- document the new nodes
- expose DSL bindings
- include tests for Base64 nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.nodes.nodetool.base64')*
- `black src/nodetool/nodes/nodetool/base64.py tests/nodetool/test_base64_nodes.py src/nodetool/dsl/nodetool/base64.py`
- `ruff check src/nodetool/dsl/nodetool/base64.py`
- `mypy src/nodetool/nodes/nodetool/base64.py tests/nodetool/test_base64_nodes.py src/nodetool/dsl/nodetool/base64.py`
- `flake8 src/nodetool/nodes/nodetool/base64.py tests/nodetool/test_base64_nodes.py src/nodetool/dsl/nodetool/base64.py`
- `nodetool package scan`
- `nodetool codegen`