### PR TITLE
Add FTP nodes

### DIFF
--- a/src/nodetool/dsl/lib/ftplib.py
+++ b/src/nodetool/dsl/lib/ftplib.py
@@ -1,0 +1,68 @@
+from pydantic import BaseModel, Field
+import typing
+from typing import Any
+import nodetool.metadata.types
+import nodetool.metadata.types as types
+from nodetool.dsl.graph import GraphNode
+
+
+class FTPDownloadFile(GraphNode):
+    """Download a file from an FTP server.
+    ftp, download, file
+
+    Use cases:
+    - Retrieve remote files for processing
+    - Backup data from an FTP server
+    - Integrate legacy FTP systems
+    """
+
+    host: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='FTP server host')
+    username: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Username for authentication')
+    password: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Password for authentication')
+    remote_path: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Remote file path to download')
+
+    @classmethod
+    def get_node_type(cls): return "lib.ftplib.FTPDownloadFile"
+
+
+
+class FTPListDirectory(GraphNode):
+    """List files in a directory on an FTP server.
+    ftp, list, directory
+
+    Use cases:
+    - Browse remote directories
+    - Check available files before download
+    - Monitor FTP server contents
+    """
+
+    host: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='FTP server host')
+    username: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Username for authentication')
+    password: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Password for authentication')
+    directory: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Remote directory to list')
+
+    @classmethod
+    def get_node_type(cls): return "lib.ftplib.FTPListDirectory"
+
+
+
+class FTPUploadFile(GraphNode):
+    """Upload a file to an FTP server.
+    ftp, upload, file
+
+    Use cases:
+    - Transfer files to an FTP server
+    - Automate backups to a remote system
+    - Integrate with legacy FTP workflows
+    """
+
+    host: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='FTP server host')
+    username: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Username for authentication')
+    password: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Password for authentication')
+    remote_path: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Remote file path to upload to')
+    document: types.DocumentRef | GraphNode | tuple[GraphNode, str] = Field(default=types.DocumentRef(type='document', uri='', asset_id=None, data=None), description='Document to upload')
+
+    @classmethod
+    def get_node_type(cls): return "lib.ftplib.FTPUploadFile"
+
+

--- a/src/nodetool/nodes/lib/ftplib.py
+++ b/src/nodetool/nodes/lib/ftplib.py
@@ -1,0 +1,120 @@
+import asyncio
+import io
+import ftplib
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.metadata.types import DocumentRef
+
+
+class FTPBaseNode(BaseNode):
+    """Base node for FTP operations.
+    ftp, network, transfer
+
+    Use cases:
+    - Provide shared connection parameters
+    - Reuse login logic across FTP nodes
+    - Hide base class from UI
+    """
+
+    host: str = Field(default="", description="FTP server host")
+    username: str = Field(default="", description="Username for authentication")
+    password: str = Field(default="", description="Password for authentication")
+
+    @classmethod
+    def is_visible(cls) -> bool:
+        return cls is not FTPBaseNode
+
+    def _connect(self) -> ftplib.FTP:
+        ftp = ftplib.FTP(self.host)
+        ftp.login(self.username, self.password)
+        return ftp
+
+
+class FTPDownloadFile(FTPBaseNode):
+    """Download a file from an FTP server.
+    ftp, download, file
+
+    Use cases:
+    - Retrieve remote files for processing
+    - Backup data from an FTP server
+    - Integrate legacy FTP systems
+    """
+
+    remote_path: str = Field(default="", description="Remote file path to download")
+
+    @classmethod
+    def get_title(cls):
+        return "Download File"
+
+    async def process(self, context: ProcessingContext) -> DocumentRef:
+        if not self.remote_path:
+            raise ValueError("remote_path cannot be empty")
+
+        def _download() -> bytes:
+            with self._connect() as ftp:
+                buffer = io.BytesIO()
+                ftp.retrbinary(f"RETR {self.remote_path}", buffer.write)
+                return buffer.getvalue()
+
+        data = await asyncio.to_thread(_download)
+        return DocumentRef(data=data)
+
+
+class FTPUploadFile(FTPBaseNode):
+    """Upload a file to an FTP server.
+    ftp, upload, file
+
+    Use cases:
+    - Transfer files to an FTP server
+    - Automate backups to a remote system
+    - Integrate with legacy FTP workflows
+    """
+
+    remote_path: str = Field(default="", description="Remote file path to upload to")
+    document: DocumentRef = Field(
+        default=DocumentRef(), description="Document to upload"
+    )
+
+    @classmethod
+    def get_title(cls):
+        return "Upload File"
+
+    async def process(self, context: ProcessingContext) -> None:
+        if not self.remote_path:
+            raise ValueError("remote_path cannot be empty")
+
+        data = await context.asset_to_bytes(self.document)
+
+        def _upload() -> None:
+            with self._connect() as ftp:
+                ftp.storbinary(f"STOR {self.remote_path}", io.BytesIO(data))
+
+        await asyncio.to_thread(_upload)
+        return None
+
+
+class FTPListDirectory(FTPBaseNode):
+    """List files in a directory on an FTP server.
+    ftp, list, directory
+
+    Use cases:
+    - Browse remote directories
+    - Check available files before download
+    - Monitor FTP server contents
+    """
+
+    directory: str = Field(default="", description="Remote directory to list")
+
+    @classmethod
+    def get_title(cls):
+        return "List Directory"
+
+    async def process(self, context: ProcessingContext) -> list[str]:
+        def _list() -> list[str]:
+            with self._connect() as ftp:
+                if self.directory:
+                    ftp.cwd(self.directory)
+                return ftp.nlst()
+
+        return await asyncio.to_thread(_list)

--- a/tests/nodetool/test_ftplib.py
+++ b/tests/nodetool/test_ftplib.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from nodetool.nodes.lib.ftplib import FTPDownloadFile, FTPUploadFile, FTPListDirectory
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.metadata.types import DocumentRef
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+@patch("ftplib.FTP")
+async def test_download_file(mock_ftp_cls, context):
+    mock_ftp = MagicMock()
+    mock_ftp_cls.return_value = mock_ftp
+    data = b"hello"
+
+    def retrbinary(cmd, callback):
+        assert cmd == "RETR remote.txt"
+        callback(data)
+
+    mock_ftp.retrbinary.side_effect = retrbinary
+
+    node = FTPDownloadFile(
+        host="ftp.example.com", username="u", password="p", remote_path="remote.txt"
+    )
+    result = await node.process(context)
+
+    assert isinstance(result, DocumentRef)
+    assert result.data == data
+    mock_ftp.login.assert_called_once_with("u", "p")
+    mock_ftp.retrbinary.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("ftplib.FTP")
+async def test_upload_file(mock_ftp_cls, context):
+    mock_ftp = MagicMock()
+    mock_ftp_cls.return_value = mock_ftp
+
+    node = FTPUploadFile(
+        host="ftp.example.com",
+        username="u",
+        password="p",
+        remote_path="upload.txt",
+        document=DocumentRef(data=b"hello"),
+    )
+
+    await node.process(context)
+
+    mock_ftp.login.assert_called_once_with("u", "p")
+    assert mock_ftp.storbinary.call_args[0][0] == "STOR upload.txt"
+
+
+@pytest.mark.asyncio
+@patch("ftplib.FTP")
+async def test_list_directory(mock_ftp_cls, context):
+    mock_ftp = MagicMock()
+    mock_ftp_cls.return_value = mock_ftp
+    mock_ftp.nlst.return_value = ["a.txt", "b.txt"]
+
+    node = FTPListDirectory(
+        host="ftp.example.com",
+        username="u",
+        password="p",
+        directory="data",
+    )
+
+    files = await node.process(context)
+
+    mock_ftp.login.assert_called_once_with("u", "p")
+    mock_ftp.cwd.assert_called_once_with("data")
+    assert files == ["a.txt", "b.txt"]


### PR DESCRIPTION
## Summary
- add nodes for FTP operations using ftplib
- generate DSL stubs for the new nodes
- test FTP nodes via mocking

## Testing
- `pip install .` *(fails: build dependencies canceled)*
- `black .`
- `ruff check .`
- `mypy .` *(fails: shadowing library module)*
- `flake8` *(fails: many E501 issues)*
- `nodetool package scan`
- `nodetool codegen`
- `pytest -q` *(fails: ModuleNotFoundError: nodetool.nodes.lib.ftplib)*