### PR TITLE
Add urllib helper nodes

### DIFF
--- a/src/nodetool/dsl/lib/urllib.py
+++ b/src/nodetool/dsl/lib/urllib.py
@@ -1,0 +1,99 @@
+from pydantic import BaseModel, Field
+import typing
+from typing import Any
+import nodetool.metadata.types
+import nodetool.metadata.types as types
+from nodetool.dsl.graph import GraphNode
+
+
+class EncodeQueryParams(GraphNode):
+    """
+    Encode a dictionary of parameters into a query string using
+    ``urllib.parse.urlencode``.
+    urllib, query, encode, params
+
+    Use cases:
+    - Build GET request URLs
+    - Serialize data for APIs
+    - Convert parameters to query strings
+    """
+
+    params: dict[str, str] | GraphNode | tuple[GraphNode, str] = Field(default=PydanticUndefined, description='Parameters to encode')
+
+    @classmethod
+    def get_node_type(cls): return "lib.urllib.EncodeQueryParams"
+
+
+
+class JoinURL(GraphNode):
+    """
+    Join a base URL with a relative URL using ``urllib.parse.urljoin``.
+    urllib, join, url
+
+    Use cases:
+    - Build absolute links from relative paths
+    - Combine API base with endpoints
+    - Resolve resources from a base URL
+    """
+
+    base: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Base URL')
+    url: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Relative or absolute URL')
+
+    @classmethod
+    def get_node_type(cls): return "lib.urllib.JoinURL"
+
+
+
+class ParseURL(GraphNode):
+    """
+    Parse a URL into its components using ``urllib.parse.urlparse``.
+    urllib, parse, url
+
+    Use cases:
+    - Inspect links for validation
+    - Extract host or path information
+    - Analyze query parameters
+    """
+
+    url: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='URL to parse')
+
+    @classmethod
+    def get_node_type(cls): return "lib.urllib.ParseURL"
+
+
+
+class QuoteURL(GraphNode):
+    """
+    Percent-encode a string for safe use in URLs using ``urllib.parse.quote``.
+    urllib, quote, encode
+
+    Use cases:
+    - Escape spaces or special characters
+    - Prepare text for query parameters
+    - Encode file names in URLs
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Text to quote')
+
+    @classmethod
+    def get_node_type(cls): return "lib.urllib.QuoteURL"
+
+
+
+class UnquoteURL(GraphNode):
+    """
+    Decode a percent-encoded URL string using ``urllib.parse.unquote``.
+    urllib, unquote, decode
+
+    Use cases:
+    - Convert encoded URLs to readable form
+    - Parse user input from URLs
+    - Display unescaped paths
+    """
+
+    text: str | GraphNode | tuple[GraphNode, str] = Field(default='', description='Encoded text')
+
+    @classmethod
+    def get_node_type(cls): return "lib.urllib.UnquoteURL"
+
+

--- a/src/nodetool/nodes/lib/urllib.py
+++ b/src/nodetool/nodes/lib/urllib.py
@@ -1,0 +1,125 @@
+from urllib.parse import urlparse, urljoin, urlencode, quote, unquote
+from pydantic import Field
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class ParseURL(BaseNode):
+    """
+    Parse a URL into its components using ``urllib.parse.urlparse``.
+    urllib, parse, url
+
+    Use cases:
+    - Inspect links for validation
+    - Extract host or path information
+    - Analyze query parameters
+    """
+
+    url: str = Field(default="", description="URL to parse")
+
+    @classmethod
+    def get_title(cls):
+        return "Parse URL"
+
+    async def process(self, context: ProcessingContext) -> dict:
+        parsed = urlparse(self.url)
+        return {
+            "scheme": parsed.scheme,
+            "netloc": parsed.netloc,
+            "path": parsed.path,
+            "params": parsed.params,
+            "query": parsed.query,
+            "fragment": parsed.fragment,
+            "username": parsed.username,
+            "password": parsed.password,
+            "hostname": parsed.hostname,
+            "port": parsed.port,
+        }
+
+
+class JoinURL(BaseNode):
+    """
+    Join a base URL with a relative URL using ``urllib.parse.urljoin``.
+    urllib, join, url
+
+    Use cases:
+    - Build absolute links from relative paths
+    - Combine API base with endpoints
+    - Resolve resources from a base URL
+    """
+
+    base: str = Field(default="", description="Base URL")
+    url: str = Field(default="", description="Relative or absolute URL")
+
+    @classmethod
+    def get_title(cls):
+        return "Join URL"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return urljoin(self.base, self.url)
+
+
+class EncodeQueryParams(BaseNode):
+    """
+    Encode a dictionary of parameters into a query string using
+    ``urllib.parse.urlencode``.
+    urllib, query, encode, params
+
+    Use cases:
+    - Build GET request URLs
+    - Serialize data for APIs
+    - Convert parameters to query strings
+    """
+
+    params: dict[str, str] = Field(
+        default_factory=dict, description="Parameters to encode"
+    )
+
+    @classmethod
+    def get_title(cls):
+        return "Encode Query Params"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return urlencode(self.params, doseq=True)
+
+
+class QuoteURL(BaseNode):
+    """
+    Percent-encode a string for safe use in URLs using ``urllib.parse.quote``.
+    urllib, quote, encode
+
+    Use cases:
+    - Escape spaces or special characters
+    - Prepare text for query parameters
+    - Encode file names in URLs
+    """
+
+    text: str = Field(default="", description="Text to quote")
+
+    @classmethod
+    def get_title(cls):
+        return "Quote URL"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return quote(self.text)
+
+
+class UnquoteURL(BaseNode):
+    """
+    Decode a percent-encoded URL string using ``urllib.parse.unquote``.
+    urllib, unquote, decode
+
+    Use cases:
+    - Convert encoded URLs to readable form
+    - Parse user input from URLs
+    - Display unescaped paths
+    """
+
+    text: str = Field(default="", description="Encoded text")
+
+    @classmethod
+    def get_title(cls):
+        return "Unquote URL"
+
+    async def process(self, context: ProcessingContext) -> str:
+        return unquote(self.text)

--- a/tests/nodetool/test_urllib.py
+++ b/tests/nodetool/test_urllib.py
@@ -1,0 +1,47 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.lib.urllib import (
+    ParseURL,
+    JoinURL,
+    EncodeQueryParams,
+    QuoteURL,
+    UnquoteURL,
+)
+
+
+@pytest.fixture
+def context():
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_parse_url(context: ProcessingContext):
+    node = ParseURL(url="https://example.com/path?x=1#frag")
+    result = await node.process(context)
+    assert result["scheme"] == "https"
+    assert result["netloc"] == "example.com"
+    assert result["path"] == "/path"
+    assert result["query"] == "x=1"
+    assert result["fragment"] == "frag"
+
+
+@pytest.mark.asyncio
+async def test_join_url(context: ProcessingContext):
+    node = JoinURL(base="https://example.com/api/", url="v1")
+    result = await node.process(context)
+    assert result == "https://example.com/api/v1"
+
+
+@pytest.mark.asyncio
+async def test_encode_query_params(context: ProcessingContext):
+    node = EncodeQueryParams(params={"a": "1", "b": "2"})
+    result = await node.process(context)
+    assert "a=1" in result and "b=2" in result
+
+
+@pytest.mark.asyncio
+async def test_quote_unquote(context: ProcessingContext):
+    quoted = await QuoteURL(text="hello world").process(context)
+    assert "%20" in quoted
+    unquoted = await UnquoteURL(text=quoted).process(context)
+    assert unquoted == "hello world"


### PR DESCRIPTION
## Summary
- add urllib helper node implementations
- generate DSL wrappers for new urllib nodes
- test urllib nodes

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement poetry-core)*
- `black src/nodetool/nodes/lib/urllib.py tests/nodetool/test_urllib.py`
- `ruff check .`
- `mypy .`
- `flake8 src/nodetool/nodes/lib/urllib.py tests/nodetool/test_urllib.py`
- `pytest tests/nodetool/test_urllib.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Tone' from 'nodetool.nodes.nodetool.audio')*
- `nodetool package scan`
- `nodetool codegen`