### PR TITLE
Add secrets nodes

### DIFF
--- a/src/nodetool/nodes/nodetool/secret.py
+++ b/src/nodetool/nodes/nodetool/secret.py
@@ -1,0 +1,39 @@
+from nodetool.common.environment import Environment
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.processing_context import ProcessingContext
+from pydantic import Field
+
+
+class GetSecret(BaseNode):
+    """
+    Get a secret value from configuration.
+    secrets, credentials, configuration
+    """
+
+    name: str = Field(default="", description="Secret key name")
+    default: str | None = Field(
+        default=None,
+        description="Default value if not found",
+    )
+
+    async def process(self, context: ProcessingContext) -> str | None:
+        return Environment.get(self.name, self.default)
+
+
+class SetSecret(BaseNode):
+    """
+    Set a secret value and persist it.
+    secrets, credentials, configuration
+    """
+
+    name: str = Field(default="", description="Secret key name")
+    value: str = Field(default="", description="Secret value")
+
+    async def process(self, context: ProcessingContext) -> None:
+        from nodetool.common.settings import save_settings
+
+        settings = Environment.get_settings()
+        secrets = Environment.get_secrets()
+        secrets[self.name] = self.value
+        save_settings(settings, secrets)
+        return None

--- a/tests/nodetool/test_secret_nodes.py
+++ b/tests/nodetool/test_secret_nodes.py
@@ -1,0 +1,18 @@
+import pytest
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.nodes.nodetool.secret import SetSecret, GetSecret
+
+
+@pytest.fixture
+def context(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return ProcessingContext(user_id="test", auth_token="test")
+
+
+@pytest.mark.asyncio
+async def test_secret_nodes(context: ProcessingContext):
+    set_node = SetSecret(name="TEST_SECRET", value="value")
+    await set_node.process(context)
+    get_node = GetSecret(name="TEST_SECRET")
+    result = await get_node.process(context)
+    assert result == "value"


### PR DESCRIPTION
## Summary
- implement GetSecret and SetSecret nodes
- test new secret nodes

## Testing
- `ruff check src/nodetool/nodes/nodetool/secret.py`
- `flake8 src/nodetool/nodes/nodetool/secret.py`
- `mypy src/nodetool/nodes/nodetool/secret.py` *(fails: Library stubs not installed)*
- `ruff check tests/nodetool/test_secret_nodes.py`
- `flake8 tests/nodetool/test_secret_nodes.py`
- `PYTHONPATH=src pytest -q` *(fails: ImportError: cannot import name 'Tone')*