### PR TITLE
Add DSL examples for concept art, product mockups, and interior design pipelines

### DIFF
--- a/src/nodetool/examples/nodetool-base/concept_art_generator_dsl.py
+++ b/src/nodetool/examples/nodetool-base/concept_art_generator_dsl.py
@@ -1,0 +1,156 @@
+"""
+Concept Art Generator DSL Example
+
+Transform a single story idea into three complementary concept art frames.
+
+Workflow:
+1. **Narrative Inputs** – Define the core theme, key character, and cinematic mood.
+2. **Prompt Crafting** – Shape tailored prompts for establishing, action, and detail shots.
+3. **Text-to-Image Generation** – Render scene variations with high-resolution settings.
+4. **Prompt Manifest** – Output the exact prompts for reproducibility and iteration.
+"""
+
+from nodetool.dsl.graph import create_graph, run_graph
+from nodetool.dsl.nodetool.input import StringInput
+from nodetool.dsl.nodetool.text import FormatText
+from nodetool.dsl.nodetool.image import TextToImage
+from nodetool.dsl.nodetool.output import ImageOutput, StringOutput
+from nodetool.workflows.processing_context import AssetOutputMode
+
+
+# --- Narrative Inputs --------------------------------------------------------
+concept_theme = StringInput(
+    name="concept_theme",
+    description="World-building hook or setting", 
+    value="Solar punk city rooftop gardens reconnecting nature and technology",
+)
+
+hero_focus = StringInput(
+    name="hero_focus",
+    description="Protagonist description",
+    value="A young botanist engineer with braided hair, modular exo-suit, and bioluminescent tools",
+)
+
+mood_direction = StringInput(
+    name="mood_direction",
+    description="Overall tone and lighting",
+    value="Optimistic dusk lighting with warm rim light, misty atmosphere, hopeful energy",
+)
+
+camera_brief = StringInput(
+    name="camera_brief",
+    description="Desired composition or perspective",
+    value="Dynamic wide-angle composition with layered depth cues",
+)
+
+# --- Prompt Crafting ---------------------------------------------------------
+base_prompt = FormatText(
+    template="""{{ theme }}. {{ mood }}. Cinematic illustration style, hyper-detailed, artstation trending.""",
+    theme=concept_theme.output,
+    mood=mood_direction.output,
+)
+
+establishing_prompt = FormatText(
+    template="""{{ base }} Scene focus: panoramic establishing shot showcasing architectural silhouettes, elevated gardens, suspended walkways, atmospheric perspective, volumetric lighting. Camera direction: {{ camera }}.""",
+    base=base_prompt.output,
+    camera=camera_brief.output,
+)
+
+action_prompt = FormatText(
+    template="""{{ base }} Character focus: {{ hero }} mid-action tending to kinetic hydroponic arrays, motion trails, storytelling props, expressive body language. Capture sense of scale with foreground foliage and distant city core.""",
+    base=base_prompt.output,
+    hero=hero_focus.output,
+)
+
+detail_prompt = FormatText(
+    template="""{{ base }} Detail focus: close-up of engineered plants with translucent leaves, glowing sap lines, and micro-drones pollinating. Macro depth of field, crisp material rendering, intricate surface textures.""",
+    base=base_prompt.output,
+)
+
+negative_prompt = (
+    "low resolution, blurry, dull colors, watermark, text overlay, distorted anatomy, extra limbs, frame, border"
+)
+
+# --- Text-to-Image Generation ------------------------------------------------
+establishing_render = TextToImage(
+    prompt=establishing_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1152,
+    height=640,
+    guidance_scale=6.0,
+    num_inference_steps=28,
+)
+
+action_render = TextToImage(
+    prompt=action_prompt.output,
+    negative_prompt=negative_prompt,
+    width=896,
+    height=1152,
+    guidance_scale=6.5,
+    num_inference_steps=30,
+)
+
+detail_render = TextToImage(
+    prompt=detail_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1024,
+    height=1024,
+    guidance_scale=7.0,
+    num_inference_steps=32,
+)
+
+# --- Outputs -----------------------------------------------------------------
+establishing_output = ImageOutput(
+    name="establishing_scene",
+    description="Panoramic world-building frame",
+    value=establishing_render.output,
+)
+
+action_output = ImageOutput(
+    name="hero_moment",
+    description="Character-focused action beat",
+    value=action_render.output,
+)
+
+detail_output = ImageOutput(
+    name="detail_macro",
+    description="Macro detail exploration",
+    value=detail_render.output,
+)
+
+prompt_manifest = FormatText(
+    template="""# Concept Art Prompt Manifest
+
+- Establishing Scene Prompt:\n{{ establish }}
+- Hero Moment Prompt:\n{{ action }}
+- Detail Macro Prompt:\n{{ detail }}
+
+Negative Prompt:\n{{ negative }}
+""",
+    establish=establishing_prompt.output,
+    action=action_prompt.output,
+    detail=detail_prompt.output,
+    negative=negative_prompt,
+)
+
+prompt_output = StringOutput(
+    name="prompt_manifest",
+    description="Prompts used for each render",
+    value=prompt_manifest.output,
+)
+
+# --- Graph -------------------------------------------------------------------
+graph = create_graph(
+    establishing_output,
+    action_output,
+    detail_output,
+    prompt_output,
+)
+
+
+if __name__ == "__main__":
+    results = run_graph(graph, asset_output_mode=AssetOutputMode.WORKSPACE)
+    print("Generated assets:")
+    for key in ["establishing_scene", "hero_moment", "detail_macro"]:
+        print(f"- {key}: {results[key]}")
+    print("\nPrompts:\n", results["prompt_manifest"])

--- a/src/nodetool/examples/nodetool-base/interior_design_visualizer_dsl.py
+++ b/src/nodetool/examples/nodetool-base/interior_design_visualizer_dsl.py
@@ -1,0 +1,156 @@
+"""
+Interior Design Visualizer DSL Example
+
+Generate cohesive interior design shots that explore layout, styling, and material palettes.
+
+Workflow:
+1. **Design Brief Inputs** – Capture room type, style, color palette, and focal feature.
+2. **Prompt Generation** – Derive prompts for layout plan, styled vignette, and material board.
+3. **Text-to-Image Rendering** – Produce high-resolution visualizations for each angle.
+4. **Design Packet Summary** – Output prompts for reuse alongside design narrative.
+"""
+
+from nodetool.dsl.graph import create_graph, run_graph
+from nodetool.dsl.nodetool.input import StringInput
+from nodetool.dsl.nodetool.text import FormatText
+from nodetool.dsl.nodetool.image import TextToImage
+from nodetool.dsl.nodetool.output import ImageOutput, StringOutput
+from nodetool.workflows.processing_context import AssetOutputMode
+
+
+# --- Design Brief Inputs -----------------------------------------------------
+room_type = StringInput(
+    name="room_type",
+    description="Room being designed",
+    value="Open concept living room with reading nook",
+)
+
+style_direction = StringInput(
+    name="style_direction",
+    description="Interior design style",
+    value="Japandi fusion of Japanese minimalism and Scandinavian warmth",
+)
+
+palette_direction = StringInput(
+    name="palette_direction",
+    description="Color palette guidance",
+    value="Soft clay neutrals, charcoal contrast, muted forest green accents",
+)
+
+focal_feature = StringInput(
+    name="focal_feature",
+    description="Signature element to highlight",
+    value="Custom built-in shelving with integrated lighting and curved edges",
+)
+
+# --- Prompt Generation -------------------------------------------------------
+base_design_prompt = FormatText(
+    template="""{{ room }} styled in {{ style }} with palette {{ palette }}. Natural light, realistic rendering, design-magazine photography.""",
+    room=room_type.output,
+    style=style_direction.output,
+    palette=palette_direction.output,
+)
+
+layout_prompt = FormatText(
+    template="""{{ base }} Shot type: wide layout view showing circulation flow, furniture arrangement, and focal element {{ focal }}. Render floor-to-ceiling perspective with architectural accuracy.""",
+    base=base_design_prompt.output,
+    focal=focal_feature.output,
+)
+
+vignette_prompt = FormatText(
+    template="""{{ base }} Shot type: styled vignette focusing on seating area, layered textiles, curated accessories, and ambient lighting. Include subtle human touch like open book or tea set.""",
+    base=base_design_prompt.output,
+)
+
+material_prompt = FormatText(
+    template="""{{ base }} Shot type: flat-lay material board featuring textiles, woods, stone samples, and metal finishes. Arrange swatches neatly with shadows and labeling tape aesthetic.""",
+    base=base_design_prompt.output,
+)
+
+negative_prompt = (
+    "low resolution, cluttered composition, watermark, text overlay, exaggerated proportions, warped perspective, lens distortion"
+)
+
+# --- Text-to-Image Rendering -------------------------------------------------
+layout_render = TextToImage(
+    prompt=layout_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1280,
+    height=960,
+    guidance_scale=6.8,
+    num_inference_steps=28,
+)
+
+vignette_render = TextToImage(
+    prompt=vignette_prompt.output,
+    negative_prompt=negative_prompt,
+    width=960,
+    height=1280,
+    guidance_scale=7.0,
+    num_inference_steps=30,
+)
+
+material_render = TextToImage(
+    prompt=material_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1024,
+    height=1024,
+    guidance_scale=6.2,
+    num_inference_steps=24,
+)
+
+# --- Outputs -----------------------------------------------------------------
+layout_output = ImageOutput(
+    name="layout_view",
+    description="Overall room layout visualization",
+    value=layout_render.output,
+)
+
+vignette_output = ImageOutput(
+    name="styled_vignette",
+    description="Intimate styled moment",
+    value=vignette_render.output,
+)
+
+material_output = ImageOutput(
+    name="material_board",
+    description="Flat-lay material exploration",
+    value=material_render.output,
+)
+
+design_packet = FormatText(
+    template="""# Interior Design Prompt Packet
+
+- Layout View:\n{{ layout }}
+- Styled Vignette:\n{{ vignette }}
+- Material Board:\n{{ material }}
+
+Negative Prompt:\n{{ negative }}
+""",
+    layout=layout_prompt.output,
+    vignette=vignette_prompt.output,
+    material=material_prompt.output,
+    negative=negative_prompt,
+)
+
+packet_output = StringOutput(
+    name="design_packet",
+    description="Prompts and directions for each visualization",
+    value=design_packet.output,
+)
+
+# --- Graph -------------------------------------------------------------------
+graph = create_graph(
+    layout_output,
+    vignette_output,
+    material_output,
+    packet_output,
+)
+
+
+if __name__ == "__main__":
+    results = run_graph(graph, asset_output_mode=AssetOutputMode.WORKSPACE)
+    print("Generated interior design visuals:")
+    for key in ["layout_view", "styled_vignette", "material_board"]:
+        print(f"- {key}: {results[key]}")
+    print("\nPrompts:\n", results["design_packet"])

--- a/src/nodetool/examples/nodetool-base/product_mockup_generator_dsl.py
+++ b/src/nodetool/examples/nodetool-base/product_mockup_generator_dsl.py
@@ -1,0 +1,157 @@
+"""
+Product Mockup Generator DSL Example
+
+Produce coordinated product imagery for ecommerce listings in a single run.
+
+Workflow:
+1. **Brand Inputs** – Capture product, materials, brand tone, and backdrop direction.
+2. **Prompt Assembly** – Build prompts for hero, lifestyle, and detail views.
+3. **Text-to-Image Rendering** – Generate high-resolution assets tuned for each shot type.
+4. **Prompt Reference Sheet** – Emit prompts for future regeneration or edits.
+"""
+
+from nodetool.dsl.graph import create_graph, run_graph
+from nodetool.dsl.nodetool.input import StringInput
+from nodetool.dsl.nodetool.text import FormatText
+from nodetool.dsl.nodetool.image import TextToImage
+from nodetool.dsl.nodetool.output import ImageOutput, StringOutput
+from nodetool.workflows.processing_context import AssetOutputMode
+
+
+# --- Brand Inputs ------------------------------------------------------------
+product_name = StringInput(
+    name="product_name",
+    description="Name and category of the product",
+    value="Minimalist ceramic pour-over coffee brewer",
+)
+
+material_palette = StringInput(
+    name="material_palette",
+    description="Primary materials or finishes",
+    value="Matte white ceramic with brushed brass accents",
+)
+
+brand_voice = StringInput(
+    name="brand_voice",
+    description="Desired brand tone or adjectives",
+    value="Scandinavian minimalism, calm, premium craftsmanship",
+)
+
+backdrop_direction = StringInput(
+    name="backdrop_direction",
+    description="Background or scene direction",
+    value="Soft morning light studio with neutral textures and subtle steam",
+)
+
+# --- Prompt Assembly ---------------------------------------------------------
+base_brand_prompt = FormatText(
+    template="""{{ product }} crafted from {{ materials }}. Brand tone: {{ voice }}. Render with crisp lighting, editorial clarity, realistic materials.""",
+    product=product_name.output,
+    materials=material_palette.output,
+    voice=brand_voice.output,
+)
+
+hero_prompt = FormatText(
+    template="""{{ base }} Shot type: hero product close-up on pedestal, symmetrical composition, 45-degree angle, clean shadows, negative space. Background: {{ backdrop }}.""",
+    base=base_brand_prompt.output,
+    backdrop=backdrop_direction.output,
+)
+
+lifestyle_prompt = FormatText(
+    template="""{{ base }} Shot type: lifestyle scene on kitchen counter with curated props (fresh coffee beans, linen towel, ceramic cups). Capture steam and gentle sunlight, depth-of-field bokeh. Background: {{ backdrop }}.""",
+    base=base_brand_prompt.output,
+    backdrop=backdrop_direction.output,
+)
+
+detail_prompt = FormatText(
+    template="""{{ base }} Shot type: macro detail focusing on pour spout texture, brass handle connection, and subtle surface reflections. Include droplets and tactile highlights.""",
+    base=base_brand_prompt.output,
+)
+
+negative_prompt = (
+    "low resolution, noisy texture, watermark, text overlay, extra limbs, distorted shapes, cluttered background, harsh shadows"
+)
+
+# --- Text-to-Image Rendering -------------------------------------------------
+hero_render = TextToImage(
+    prompt=hero_prompt.output,
+    negative_prompt=negative_prompt,
+    width=960,
+    height=1280,
+    guidance_scale=7.0,
+    num_inference_steps=28,
+)
+
+lifestyle_render = TextToImage(
+    prompt=lifestyle_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1280,
+    height=960,
+    guidance_scale=6.5,
+    num_inference_steps=26,
+)
+
+detail_render = TextToImage(
+    prompt=detail_prompt.output,
+    negative_prompt=negative_prompt,
+    width=1024,
+    height=1024,
+    guidance_scale=7.2,
+    num_inference_steps=30,
+)
+
+# --- Outputs -----------------------------------------------------------------
+hero_output = ImageOutput(
+    name="hero_product_shot",
+    description="Primary ecommerce hero image",
+    value=hero_render.output,
+)
+
+lifestyle_output = ImageOutput(
+    name="lifestyle_scene",
+    description="Styled environment shot",
+    value=lifestyle_render.output,
+)
+
+detail_output = ImageOutput(
+    name="detail_macro",
+    description="Macro craftsmanship highlight",
+    value=detail_render.output,
+)
+
+prompt_summary = FormatText(
+    template="""# Product Mockup Prompts
+
+- Hero Shot:\n{{ hero }}
+- Lifestyle Scene:\n{{ lifestyle }}
+- Detail Macro:\n{{ detail }}
+
+Negative Prompt:\n{{ negative }}
+""",
+    hero=hero_prompt.output,
+    lifestyle=lifestyle_prompt.output,
+    detail=detail_prompt.output,
+    negative=negative_prompt,
+)
+
+prompt_output = StringOutput(
+    name="prompt_summary",
+    description="Reference sheet for the generated prompts",
+    value=prompt_summary.output,
+)
+
+# --- Graph -------------------------------------------------------------------
+graph = create_graph(
+    hero_output,
+    lifestyle_output,
+    detail_output,
+    prompt_output,
+)
+
+
+if __name__ == "__main__":
+    results = run_graph(graph, asset_output_mode=AssetOutputMode.WORKSPACE)
+    print("Generated product visuals:")
+    for key in ["hero_product_shot", "lifestyle_scene", "detail_macro"]:
+        print(f"- {key}: {results[key]}")
+    print("\nPrompts:\n", results["prompt_summary"])


### PR DESCRIPTION
## Summary
- add a concept art generator DSL workflow that creates three complementary renders and manifest output
- add a product mockup generator DSL workflow covering hero, lifestyle, and detail shots with prompt summary
- add an interior design visualizer DSL workflow for layout, vignette, and material board imagery

## Testing
- python -m compileall src/nodetool/examples/nodetool-base/concept_art_generator_dsl.py src/nodetool/examples/nodetool-base/product_mockup_generator_dsl.py src/nodetool/examples/nodetool-base/interior_design_visualizer_dsl.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69046df3a8f8832d9f51dde95edf3051)