### PR TITLE
⚡ Bolt: Offload pandas CSV read/write to thread

### DIFF
--- a/src/nodetool/nodes/nodetool/data.py
+++ b/src/nodetool/nodes/nodetool/data.py
@@ -1,6 +1,7 @@
 from .utils import generate_timestamped_name
 from io import StringIO
 from typing import AsyncGenerator, ClassVar, TypedDict
+import asyncio
 import json
 import os
 import pandas as pd
@@ -18,7 +19,7 @@ class Schema(BaseNode):
     Define a schema for a dataframe.
     schema, dataframe, create
     """
-    
+
     columns: RecordType = Field(
         default=RecordType(),
         description="The columns to use in the dataframe.",
@@ -26,7 +27,7 @@ class Schema(BaseNode):
 
     async def process(self, context: ProcessingContext) -> RecordType:
         return self.columns
-    
+
 
 class Filter(BaseNode):
     """
@@ -136,12 +137,11 @@ class SaveDataframe(BaseNode):
         result = await context.dataframe_from_pandas(df, filename, parent_id)
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -176,7 +176,7 @@ class LoadCSVURL(BaseNode):
     url: str = Field(default="", description="The URL of the CSV file to load.")
 
     async def process(self, context: ProcessingContext) -> DataframeRef:
-        df = pd.read_csv(self.url)
+        df = await asyncio.to_thread(pd.read_csv, self.url)
         return await context.dataframe_from_pandas(df)
 
 
@@ -192,7 +192,7 @@ class LoadCSVFile(BaseNode):
     async def process(self, context: ProcessingContext) -> DataframeRef:
         if not self.file_path:
             raise ValueError("file_path cannot be empty")
-        df = pd.read_csv(self.file_path)
+        df = await asyncio.to_thread(pd.read_csv, self.file_path)
         return await context.dataframe_from_pandas(df)
 
 
@@ -639,7 +639,7 @@ class LoadCSVAssets(BaseNode):
 
         for asset in list_assets:
             bytes_io = await context.download_asset(asset.id)
-            df = pd.read_csv(bytes_io)
+            df = await asyncio.to_thread(pd.read_csv, bytes_io)
             yield {
                 "name": asset.name,
                 "dataframe": await context.dataframe_from_pandas(df),
@@ -895,16 +895,15 @@ class SaveCSVDataframeFile(BaseNode):
         filename = generate_timestamped_name(self.filename)
         expanded_path = os.path.join(expanded_folder, filename)
         df = await context.dataframe_to_pandas(self.dataframe)
-        df.to_csv(expanded_path, index=False)
+        await asyncio.to_thread(df.to_csv, expanded_path, index=False)
         result = self.dataframe
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -929,11 +928,13 @@ class FilterNone(BaseNode):
     @classmethod
     def is_streaming_input(cls) -> bool:
         return True
-    
+
     class OutputType(TypedDict):
         output: Any
 
-    async def gen_process(self, context: ProcessingContext) -> AsyncGenerator[OutputType, None]:
+    async def gen_process(
+        self, context: ProcessingContext
+    ) -> AsyncGenerator[OutputType, None]:
         async for handle, item in self.iter_any_input():
             if handle == "value":
                 if item is not None:


### PR DESCRIPTION
💡 What: Wrapped synchronous `pandas` I/O operations (`pd.read_csv` and `df.to_csv`) with `await asyncio.to_thread(...)` in `LoadCSVFile`, `LoadCSVURL`, `LoadCSVAssets`, and `SaveCSVDataframeFile` nodes within `src/nodetool/nodes/nodetool/data.py`.
🎯 Why: `pandas` operations are synchronous and can be heavily blocking on both network/disk I/O and CPU parsing. Directly calling these inside `async def process(...)` blocks the main Python event loop, causing the application to freeze and become unresponsive to other concurrent tasks (e.g., HTTP processing or other nodes) during large data operations.
📊 Impact: Significantly improves concurrency and responsiveness of the application when processing large dataframes. Eliminates head-of-line blocking in the asyncio loop caused by CSV parsing and network/disk operations.
🔬 Measurement: Standalone mock testing has verified that the data passes through correctly when processed via `asyncio.to_thread`. General app responsiveness under load while processing large CSVs will improve noticeably.

---
*PR created automatically by Jules for task [17790611457641401512](https://jules.google.com/task/17790611457641401512) started by @georgi*