### PR TITLE
⚡ Bolt: Optimize dataframe iteration using to_dict('records')

### DIFF
--- a/src/nodetool/nodes/nodetool/data.py
+++ b/src/nodetool/nodes/nodetool/data.py
@@ -18,7 +18,7 @@ class Schema(BaseNode):
     Define a schema for a dataframe.
     schema, dataframe, create
     """
-    
+
     columns: RecordType = Field(
         default=RecordType(),
         description="The columns to use in the dataframe.",
@@ -26,7 +26,7 @@ class Schema(BaseNode):
 
     async def process(self, context: ProcessingContext) -> RecordType:
         return self.columns
-    
+
 
 class Filter(BaseNode):
     """
@@ -136,12 +136,11 @@ class SaveDataframe(BaseNode):
         result = await context.dataframe_from_pandas(df, filename, parent_id)
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -476,8 +475,9 @@ class RowIterator(BaseNode):
         self, context: ProcessingContext
     ) -> AsyncGenerator[OutputType, None]:
         df = await context.dataframe_to_pandas(self.dataframe)
-        for index, row in df.iterrows():
-            yield {"dict": row.to_dict(), "index": index}
+        # bolt-performance: replace slow .iterrows() with zip() and to_dict('records')
+        for index, row in zip(df.index, df.to_dict("records")):
+            yield {"dict": row, "index": index}
 
 
 class FindRow(BaseNode):
@@ -598,8 +598,9 @@ class ForEachRow(BaseNode):
         self, context: ProcessingContext
     ) -> AsyncGenerator[OutputType, None]:
         df = await context.dataframe_to_pandas(self.dataframe)
-        for index, row in df.iterrows():
-            yield {"row": row.to_dict(), "index": index}
+        # bolt-performance: replace slow .iterrows() with zip() and to_dict('records')
+        for index, row in zip(df.index, df.to_dict("records")):
+            yield {"row": row, "index": index}
 
 
 class LoadCSVAssets(BaseNode):
@@ -899,12 +900,11 @@ class SaveCSVDataframeFile(BaseNode):
         result = self.dataframe
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -929,11 +929,13 @@ class FilterNone(BaseNode):
     @classmethod
     def is_streaming_input(cls) -> bool:
         return True
-    
+
     class OutputType(TypedDict):
         output: Any
 
-    async def gen_process(self, context: ProcessingContext) -> AsyncGenerator[OutputType, None]:
+    async def gen_process(
+        self, context: ProcessingContext
+    ) -> AsyncGenerator[OutputType, None]:
         async for handle, item in self.iter_any_input():
             if handle == "value":
                 if item is not None:


### PR DESCRIPTION
💡 What: Replaced `df.iterrows()` with `zip(df.index, df.to_dict("records"))` in `RowIterator` and `ForEachRow` gen_process routines.
🎯 Why: Iterating with `df.iterrows()` creates a new `Series` object per row resulting in tremendous performance overhead, and also causes issues with pandas up-casting scalar values to find a common datatype across columns within a given row.
📊 Impact: Standard tests for python iterate rows typically observe an order of ~20x faster bulk dictionary conversion that correctly handles non-unique indices.
🔬 Measurement: Verify by executing row iterations within nodetool pipelines; the node throughput will visibly increase for large datasets (>1k lines).

---
*PR created automatically by Jules for task [14772708608386740569](https://jules.google.com/task/14772708608386740569) started by @georgi*