### PR TITLE
⚡ Bolt: Replace slow df.iterrows() with bulk dictionary conversion

### DIFF
--- a/src/nodetool/nodes/nodetool/data.py
+++ b/src/nodetool/nodes/nodetool/data.py
@@ -18,7 +18,7 @@ class Schema(BaseNode):
     Define a schema for a dataframe.
     schema, dataframe, create
     """
-    
+
     columns: RecordType = Field(
         default=RecordType(),
         description="The columns to use in the dataframe.",
@@ -26,7 +26,7 @@ class Schema(BaseNode):
 
     async def process(self, context: ProcessingContext) -> RecordType:
         return self.columns
-    
+
 
 class Filter(BaseNode):
     """
@@ -136,12 +136,11 @@ class SaveDataframe(BaseNode):
         result = await context.dataframe_from_pandas(df, filename, parent_id)
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -476,8 +475,9 @@ class RowIterator(BaseNode):
         self, context: ProcessingContext
     ) -> AsyncGenerator[OutputType, None]:
         df = await context.dataframe_to_pandas(self.dataframe)
-        for index, row in df.iterrows():
-            yield {"dict": row.to_dict(), "index": index}
+        # Bulk conversion is ~20x faster than df.iterrows() as it avoids creating a Series per row
+        for index, row in zip(df.index, df.to_dict("records")):
+            yield {"dict": row, "index": index}
 
 
 class FindRow(BaseNode):
@@ -598,8 +598,9 @@ class ForEachRow(BaseNode):
         self, context: ProcessingContext
     ) -> AsyncGenerator[OutputType, None]:
         df = await context.dataframe_to_pandas(self.dataframe)
-        for index, row in df.iterrows():
-            yield {"row": row.to_dict(), "index": index}
+        # Bulk conversion is ~20x faster than df.iterrows() as it avoids creating a Series per row
+        for index, row in zip(df.index, df.to_dict("records")):
+            yield {"row": row, "index": index}
 
 
 class LoadCSVAssets(BaseNode):
@@ -899,12 +900,11 @@ class SaveCSVDataframeFile(BaseNode):
         result = self.dataframe
 
         # Emit SaveUpdate event
-        context.post_message(SaveUpdate(
-            node_id=self.id,
-            name=filename,
-            value=result,
-            output_type="dataframe"
-        ))
+        context.post_message(
+            SaveUpdate(
+                node_id=self.id, name=filename, value=result, output_type="dataframe"
+            )
+        )
 
         return result
 
@@ -929,11 +929,13 @@ class FilterNone(BaseNode):
     @classmethod
     def is_streaming_input(cls) -> bool:
         return True
-    
+
     class OutputType(TypedDict):
         output: Any
 
-    async def gen_process(self, context: ProcessingContext) -> AsyncGenerator[OutputType, None]:
+    async def gen_process(
+        self, context: ProcessingContext
+    ) -> AsyncGenerator[OutputType, None]:
         async for handle, item in self.iter_any_input():
             if handle == "value":
                 if item is not None:


### PR DESCRIPTION
💡 **What**: Replaced `df.iterrows()` with `zip(df.index, df.to_dict('records'))` in the `gen_process` methods of `RowIterator` and `ForEachRow` nodes in `src/nodetool/nodes/nodetool/data.py`. Also removed the redundant `.to_dict()` calls on the row variables within the loops. Added inline comments explaining the performance optimization.
🎯 **Why**: `df.iterrows()` is notoriously slow in Pandas because it constructs a new `Series` object for every single row. In loops dealing with larger datasets, this creates a significant performance bottleneck and memory overhead.
📊 **Impact**: Using `to_dict("records")` natively converts the DataFrame into a list of dictionaries at the C-level. This bulk conversion approach is typically ~20x faster than `df.iterrows()`, significantly accelerating row iteration nodes. Additionally, this approach is safer as it naturally preserves the original column data types, whereas `iterrows()` can sometimes inadvertently cast data types across a row.
🔬 **Measurement**: The improvement can be verified by running large DataFrames through the `RowIterator` or `ForEachRow` nodes and measuring execution time, which will show drastically reduced processing times. Correctness was verified via a standalone script `test_iterator_mock.py` confirming the output payload structure `{'dict': ..., 'index': ...}` remains identical. Code was linted and formatted with `ruff`.

---
*PR created automatically by Jules for task [6611463261168914078](https://jules.google.com/task/6611463261168914078) started by @georgi*